### PR TITLE
Further table improvements

### DIFF
--- a/js/inputs/table.ts
+++ b/js/inputs/table.ts
@@ -149,18 +149,15 @@ export class Table extends Input {
         this.schema_ = [];
 
         // height and width
+        this.element.classList.add('inspect-viz-table');
         if (typeof this.options_.width === 'number') {
             this.element.style.width = `${this.options_.width}px`;
-        } else {
-            this.element.style.width = '100%';
         }
         if (this.options_.max_width) {
             this.element.style.maxWidth = `${this.options_.max_width}px`;
         }
         if (this.options_.height) {
             this.element.style.height = `${this.height_}px`;
-        } else {
-            this.element.style.height = '380px';
         }
 
         // create grid container

--- a/js/inputs/table.ts
+++ b/js/inputs/table.ts
@@ -57,7 +57,7 @@ import { generateId } from '../util/id';
 import { JSType } from '@uwdata/mosaic-core';
 
 export interface Column {
-    name: string;
+    column: string;
     label?: string;
     align?: 'left' | 'right' | 'center' | 'justify';
     format?: string;
@@ -98,7 +98,6 @@ export interface TableOptions extends InputOptions {
         | 'single_checkbox'
         | 'multiple_checkbox'
         | 'none';
-    select_all_scope?: 'all' | 'filtered' | 'page';
 }
 
 interface ColSortModel {
@@ -139,7 +138,7 @@ export class Table extends Input {
         this.columns_ = resolveColumns(this.options_.columns || ['*']);
         this.columnOptions_ = this.columns_.reduce(
             (acc, col) => {
-                acc[col.name] = col;
+                acc[col.column] = col;
                 return acc;
             },
             {} as Record<string, Column>
@@ -190,7 +189,7 @@ export class Table extends Input {
     async prepare() {
         // query for column schema information
         const table = this.options_.from;
-        const fields = this.columns_.map(column => ({ column: column.name, table }));
+        const fields = this.columns_.map(column => ({ column: column.column, table }));
         this.schema_ = await queryFieldInfo(this.coordinator!, fields);
 
         // create column definitions for ag-grid
@@ -291,6 +290,7 @@ export class Table extends Input {
             rowSelection: explicitSelection,
             suppressCellFocus: true,
             enableCellTextSelection: true,
+            theme: themeBalham.withParams({}),
             onFilterChanged: () => {
                 // Capture the filter model for server-side use
                 this.filterModel_ = this.grid_?.getFilterModel() || {};
@@ -434,7 +434,7 @@ export class Table extends Input {
 const resolveColumns = (columns: Array<string | Column>): Column[] => {
     return columns.map(col => {
         if (typeof col === 'string') {
-            return { name: col };
+            return { column: col };
         } else if (typeof col === 'object' && col !== null) {
             return col as Column;
         } else {
@@ -464,11 +464,9 @@ const resolveRowSelection = (options: TableOptions): RowSelectionOptions<any, an
             enableClickSelection: options.select === 'single_row',
         };
     } else if (options.select?.startsWith('multiple_')) {
-        const selectAll = options.select_all_scope || 'all';
-        const selectAllVal = selectAll === 'page' ? 'currentPage' : selectAll;
         return {
             mode: 'multiRow',
-            selectAll: selectAllVal,
+            selectAll: 'filtered',
             checkboxes: options.select === 'multiple_checkbox',
         };
     } else {

--- a/js/inputs/table.ts
+++ b/js/inputs/table.ts
@@ -83,8 +83,7 @@ export interface TableOptions extends InputOptions {
     height?: number;
     max_width?: number;
     pagination?: {
-        auto_page_size?: boolean;
-        page_size?: number;
+        page_size?: number | 'auto';
         page_size_selector?: number[] | boolean;
     };
     sorting?: boolean;
@@ -268,7 +267,6 @@ export class Table extends Input {
     });
 
     private createGridOptions(options: TableOptions): GridOptions {
-        console.log({ options });
         const headerHeightPixels =
             typeof options.header_height === 'string' ? undefined : options.header_height;
         const hoverSelect = options.select === 'hover';
@@ -279,9 +277,14 @@ export class Table extends Input {
             // always pass filter to allow server-side filtering
             alwaysPassFilter: () => true,
             pagination: !!options.pagination,
-            paginationAutoPageSize: !!options.pagination?.auto_page_size,
+            paginationAutoPageSize:
+                options.pagination?.page_size === 'auto' ||
+                options.pagination?.page_size === undefined,
             paginationPageSizeSelector: options.pagination?.page_size_selector,
-            paginationPageSize: options.pagination?.page_size,
+            paginationPageSize:
+                typeof options.pagination?.page_size === 'number'
+                    ? options.pagination.page_size
+                    : undefined,
             animateRows: true,
             headerHeight: headerHeightPixels,
             rowHeight: options.row_height,

--- a/js/inputs/table.ts
+++ b/js/inputs/table.ts
@@ -271,7 +271,7 @@ export class Table extends Input {
         console.log({ options });
         const headerHeightPixels =
             typeof options.header_height === 'string' ? undefined : options.header_height;
-        const hoverSelect = options.select === 'hover' || options.select === undefined;
+        const hoverSelect = options.select === 'hover';
         const explicitSelection = resolveRowSelection(options);
 
         // initialize grid options
@@ -451,19 +451,18 @@ const headerClasses = (align?: 'left' | 'right' | 'center' | 'justify'): string[
 };
 
 const resolveRowSelection = (options: TableOptions): RowSelectionOptions<any, any> | undefined => {
-    const explicitSelect =
-        options.select !== 'hover' && options.select !== undefined && options.select !== 'none';
-    if (!explicitSelect) {
+    if (options.select === 'hover') {
         return undefined;
     }
 
-    if (options.select?.startsWith('single_')) {
+    const selectType = options.select || 'single_row';
+    if (selectType.startsWith('single_')) {
         return {
             mode: 'singleRow',
             checkboxes: options.select === 'single_checkbox',
             enableClickSelection: options.select === 'single_row',
         };
-    } else if (options.select?.startsWith('multiple_')) {
+    } else if (selectType.startsWith('multiple_')) {
         return {
             mode: 'multiRow',
             selectAll: 'filtered',

--- a/src/inspect_viz/_widgets/ag-grid.css
+++ b/src/inspect_viz/_widgets/ag-grid.css
@@ -1,3 +1,7 @@
+.inspect-viz-table {
+    height: 380px;
+}            
+
 .header-center .ag-header-cell-label {
     justify-content: center;
 }

--- a/src/inspect_viz/_widgets/mosaic.js
+++ b/src/inspect_viz/_widgets/mosaic.js
@@ -759,7 +759,6 @@ var Table = class extends Input {
     this.grid_.setGridOption("rowData", rowData);
   });
   createGridOptions(options) {
-    console.log({ options });
     const headerHeightPixels = typeof options.header_height === "string" ? void 0 : options.header_height;
     const hoverSelect = options.select === "hover";
     const explicitSelection = resolveRowSelection(options);
@@ -767,9 +766,9 @@ var Table = class extends Input {
       // always pass filter to allow server-side filtering
       alwaysPassFilter: () => true,
       pagination: !!options.pagination,
-      paginationAutoPageSize: !!options.pagination?.auto_page_size,
+      paginationAutoPageSize: options.pagination?.page_size === "auto" || options.pagination?.page_size === void 0,
       paginationPageSizeSelector: options.pagination?.page_size_selector,
-      paginationPageSize: options.pagination?.page_size,
+      paginationPageSize: typeof options.pagination?.page_size === "number" ? options.pagination.page_size : void 0,
       animateRows: true,
       headerHeight: headerHeightPixels,
       rowHeight: options.row_height,

--- a/src/inspect_viz/_widgets/mosaic.js
+++ b/src/inspect_viz/_widgets/mosaic.js
@@ -761,7 +761,7 @@ var Table = class extends Input {
   createGridOptions(options) {
     console.log({ options });
     const headerHeightPixels = typeof options.header_height === "string" ? void 0 : options.header_height;
-    const hoverSelect = options.select === "hover" || options.select === void 0;
+    const hoverSelect = options.select === "hover";
     const explicitSelection = resolveRowSelection(options);
     return {
       // always pass filter to allow server-side filtering
@@ -892,17 +892,17 @@ var headerClasses = (align) => {
   return [`header-${align}`];
 };
 var resolveRowSelection = (options) => {
-  const explicitSelect = options.select !== "hover" && options.select !== void 0 && options.select !== "none";
-  if (!explicitSelect) {
+  if (options.select === "hover") {
     return void 0;
   }
-  if (options.select?.startsWith("single_")) {
+  const selectType = options.select || "single_row";
+  if (selectType.startsWith("single_")) {
     return {
       mode: "singleRow",
       checkboxes: options.select === "single_checkbox",
       enableClickSelection: options.select === "single_row"
     };
-  } else if (options.select?.startsWith("multiple_")) {
+  } else if (selectType.startsWith("multiple_")) {
     return {
       mode: "multiRow",
       selectAll: "filtered",

--- a/src/inspect_viz/_widgets/mosaic.js
+++ b/src/inspect_viz/_widgets/mosaic.js
@@ -647,7 +647,7 @@ var Table = class extends Input {
     this.columns_ = resolveColumns(this.options_.columns || ["*"]);
     this.columnOptions_ = this.columns_.reduce(
       (acc, col) => {
-        acc[col.name] = col;
+        acc[col.column] = col;
         return acc;
       },
       {}
@@ -702,7 +702,7 @@ var Table = class extends Input {
   // and do related setup
   async prepare() {
     const table = this.options_.from;
-    const fields = this.columns_.map((column2) => ({ column: column2.name, table }));
+    const fields = this.columns_.map((column2) => ({ column: column2.column, table }));
     this.schema_ = await queryFieldInfo(this.coordinator, fields);
     const columnDefs = this.schema_.map(
       ({ column: column2, type }) => this.createColumnDef(column2, type)
@@ -778,6 +778,7 @@ var Table = class extends Input {
       rowSelection: explicitSelection,
       suppressCellFocus: true,
       enableCellTextSelection: true,
+      theme: themeBalham.withParams({}),
       onFilterChanged: () => {
         this.filterModel_ = this.grid_?.getFilterModel() || {};
         this.requestQuery();
@@ -876,7 +877,7 @@ var Table = class extends Input {
 var resolveColumns = (columns) => {
   return columns.map((col) => {
     if (typeof col === "string") {
-      return { name: col };
+      return { column: col };
     } else if (typeof col === "object" && col !== null) {
       return col;
     } else {
@@ -902,11 +903,9 @@ var resolveRowSelection = (options) => {
       enableClickSelection: options.select === "single_row"
     };
   } else if (options.select?.startsWith("multiple_")) {
-    const selectAll = options.select_all_scope || "all";
-    const selectAllVal = selectAll === "page" ? "currentPage" : selectAll;
     return {
       mode: "multiRow",
-      selectAll: selectAllVal,
+      selectAll: "filtered",
       checkboxes: options.select === "multiple_checkbox"
     };
   } else {

--- a/src/inspect_viz/_widgets/mosaic.js
+++ b/src/inspect_viz/_widgets/mosaic.js
@@ -655,18 +655,15 @@ var Table = class extends Input {
     this.height_ = this.options_.height;
     this.currentRow_ = -1;
     this.schema_ = [];
+    this.element.classList.add("inspect-viz-table");
     if (typeof this.options_.width === "number") {
       this.element.style.width = `${this.options_.width}px`;
-    } else {
-      this.element.style.width = "100%";
     }
     if (this.options_.max_width) {
       this.element.style.maxWidth = `${this.options_.max_width}px`;
     }
     if (this.options_.height) {
       this.element.style.height = `${this.height_}px`;
-    } else {
-      this.element.style.height = "380px";
     }
     this.gridContainer_ = document.createElement("div");
     this.gridContainer_.id = this.id_;

--- a/src/inspect_viz/_widgets/quarto.css
+++ b/src/inspect_viz/_widgets/quarto.css
@@ -84,3 +84,13 @@
 .card-body .mosaic-widget .inspect-viz-table {
     height: 100%;
 }
+
+.mosaic-widget .inspect-viz-table {
+    --ag-foreground-color: var(--bs-body-color);
+    --ag-background-color: var(--bs-body-bg);
+    --ag-accent-color: var(--bs-primary);
+    --ag-font-family: var(--bs-font-sans-serif);
+    --ag-font-size: var(--bs-font-size-base);
+
+
+}

--- a/src/inspect_viz/_widgets/quarto.css
+++ b/src/inspect_viz/_widgets/quarto.css
@@ -80,3 +80,7 @@
 .card-body .mosaic-widget .ag-root-wrapper {
     border: none;
 }
+
+.card-body .mosaic-widget .inspect-viz-table {
+    height: 100%;
+}

--- a/src/inspect_viz/table/__init__.py
+++ b/src/inspect_viz/table/__init__.py
@@ -1,3 +1,3 @@
-from ._table import Column, Pagination, table
+from ._table import Column, Pagination, column, table
 
-__all__ = ["table", "Column", "Pagination"]
+__all__ = ["table", "column", "Column", "Pagination"]

--- a/src/inspect_viz/table/_table.py
+++ b/src/inspect_viz/table/_table.py
@@ -56,6 +56,45 @@ class Column(BaseModel):
     header_auto_height: bool | None = None
     header_wrap_text: bool | None = None
 
+    def __init__(
+        self,
+        column: str,
+        *,
+        label: str | None = None,
+        align: Literal["left", "right", "center", "justify"] | None = None,
+        format: str | None = None,
+        width: float | None = None,
+        flex: float | None = None,
+        min_width: float | None = None,
+        max_width: float | None = None,
+        auto_height: bool | None = None,
+        sortable: bool | None = None,
+        filterable: bool | None = None,
+        resizable: bool | None = None,
+        wrap_text: bool | None = None,
+        header_align: Literal["left", "right", "center", "justify"] | None = None,
+        header_auto_height: bool | None = None,
+        header_wrap_text: bool | None = None,
+    ):
+        super().__init__(
+            column=column,
+            label=label,
+            align=align,
+            format=format,
+            width=width,
+            flex=flex,
+            min_width=min_width,
+            max_width=max_width,
+            auto_height=auto_height,
+            sortable=sortable,
+            filterable=filterable,
+            resizable=resizable,
+            wrap_text=wrap_text,
+            header_align=header_align,
+            header_auto_height=header_auto_height,
+            header_wrap_text=header_wrap_text,
+        )
+
 
 class Pagination(BaseModel):
     """Pagination configuration for table display.
@@ -79,6 +118,7 @@ class Pagination(BaseModel):
 
 def table(
     data: Data,
+    *,
     filter_by: Selection | None = None,
     columns: list[str | Column] | None = None,
     target: Selection | None = None,

--- a/src/inspect_viz/table/_table.py
+++ b/src/inspect_viz/table/_table.py
@@ -12,7 +12,7 @@ class Column(BaseModel):
     """Column configuration options for table display.
 
     Args:
-        name: The column name as it appears in the data source. This is required.
+        column: The column name as it appears in the data source. This is required.
         label: The text label for the column header. If not specified, the column name is used.
         align: Text alignment for the column. Valid values are "left", "right",
             "center", and "justify". By default, numbers are right-aligned and other
@@ -39,7 +39,7 @@ class Column(BaseModel):
             header cell.
     """
 
-    name: str
+    column: str
     label: str | None = None
     align: Literal["left", "right", "center", "justify"] | None = None
     format: str | None = None
@@ -99,12 +99,10 @@ def table(
         "none",
     ]
     | None = None,
-    select_all_scope: Literal["all", "filtered", "currentPage"] | None = None,
 ) -> Component:
     """Tabular display of data.
 
     Args:
-
         data: The data source for the table.
         filter_by: Selection to filter by (defaults to data source selection).
         columns: A list of column names to include in the table grid. If unspecified,
@@ -114,9 +112,6 @@ def table(
         select: The type of selection to use for the table. Valid values are "hover",
             "single_checkbox", "multiple_checkbox", "single_row", "multiple_row", and
             "none". Defaults to "hover".
-        select_all_scope: If select 'multiple' is enabled, controls the scope of the
-            select all option in the header. Valid values are 'all', 'filtered' or
-            'currentPage'.
         column_options: A dictionary of column configuration options. The keys are
             column names and the values are dictionaries with column options.
         width: The total width of the table widget, in pixels.
@@ -148,7 +143,6 @@ def table(
             "header_height": header_height,
             "row_height": row_height,
             "select": select,
-            "select_all_scope": select_all_scope,
         }
     )
 
@@ -156,7 +150,7 @@ def table(
 
 
 def validate_column(data: Data | None, column: str | Column) -> str | Column:
-    column_name = column.name if isinstance(column, Column) else column
+    column_name = column.column if isinstance(column, Column) else column
     if data is not None:
         if column_name not in data.columns:
             raise ValueError(f"Column '{column}' was not found in the data source.")

--- a/src/inspect_viz/table/_table.py
+++ b/src/inspect_viz/table/_table.py
@@ -96,6 +96,77 @@ class Column(BaseModel):
         )
 
 
+def column(
+    column: str,
+    *,
+    label: str | None = None,
+    align: Literal["left", "right", "center", "justify"] | None = None,
+    format: str | None = None,
+    width: float | None = None,
+    min_width: float | None = None,
+    max_width: float | None = None,
+    flex: float | None = None,
+    auto_height: bool | None = None,
+    sortable: bool | None = None,
+    filterable: bool | None = None,
+    resizable: bool | None = None,
+    wrap_text: bool | None = None,
+    header_align: Literal["left", "right", "center", "justify"] | None = None,
+    header_auto_height: bool | None = None,
+    header_wrap_text: bool | None = None,
+) -> Column:
+    """Create a column configuration for table display.
+
+    Args:
+        column: The column name as it appears in the data source. This is required.
+        label: The text label for the column header. If not specified, the column name is used.
+        align: Text alignment for the column. Valid values are "left", "right",
+            "center", and "justify". By default, numbers are right-aligned and other
+            values are left-aligned.
+        format: Format string for column values. Use d3-format for numeric columns or
+            d3-time-format for datetime columns.
+        width: Column width in pixels.
+        min_width: Minimum column width in pixels.
+        max_width: Maximum column width in pixels.
+        flex: The flex value of the table widget, used to determine how much space it
+            should take relative to other widgets in a layout. If specified, width is
+            ignored.
+        auto_height: Whether the column cell height is automatically adjusted based on
+            content.
+        sortable: Whether sorting is enabled for this column.
+        filterable: Whether filtering is enabled for this column.
+        resizable: Whether the column width can be adjusted by the user.
+        wrap_text: Whether the column text is wrapped to fit within the cell.
+        header_align: Text alignment for the column header. Valid values are "left",
+            "right", "center", and "justify". By default, left aligned.
+        header_auto_height: Whether the column header cell height is automatically
+            adjusted based on content.
+        header_wrap_text: Whether the column header text is wrapped to fit within the
+            header cell.
+
+    Returns:
+        Column: A configured Column object.
+    """
+    return Column(
+        column=column,
+        label=label,
+        align=align,
+        format=format,
+        width=width,
+        min_width=min_width,
+        max_width=max_width,
+        flex=flex,
+        auto_height=auto_height,
+        sortable=sortable,
+        filterable=filterable,
+        resizable=resizable,
+        wrap_text=wrap_text,
+        header_align=header_align,
+        header_auto_height=header_auto_height,
+        header_wrap_text=header_wrap_text,
+    )
+
+
 class Pagination(BaseModel):
     """Pagination configuration for table display.
 

--- a/src/inspect_viz/table/_table.py
+++ b/src/inspect_viz/table/_table.py
@@ -100,7 +100,8 @@ class Pagination(BaseModel):
     """Pagination configuration for table display.
 
     Args:
-        page_size: Number of rows to load per page.
+        page_size: Number of rows to load per page, or "auto" to fit the number of
+            rows in a page to the available space. Defaults to "auto".
         page_size_selector: Determines if the page size selector is shown in the
             pagination panel or not. Set to a list of values to show the page size
             selector with custom list of possible page sizes. Set to true to show the
@@ -108,12 +109,22 @@ class Pagination(BaseModel):
             to hide the page size selector.
         auto_page_size: If true, the number of rows to load per page is automatically
             adjusted by the grid so each page shows enough rows to just fill the area
-            designated for the grid. If false, paginationPageSize is used.
+            designated for the grid. If false, page_size is used.
     """
 
-    page_size: int | None = None
+    page_size: int | Literal["auto"] | None = None
     page_size_selector: list[int] | bool | None = None
-    auto_page_size: bool | None = None
+
+    def __init__(
+        self,
+        page_size: int | Literal["auto"] | None = None,
+        *,
+        page_size_selector: list[int] | bool | None = None,
+    ):
+        super().__init__(
+            page_size=page_size,
+            page_size_selector=page_size_selector,
+        )
 
 
 def table(

--- a/src/inspect_viz/table/_table.py
+++ b/src/inspect_viz/table/_table.py
@@ -151,7 +151,7 @@ def table(
             will be added to the selection for each currently selected table row.
         select: The type of selection to use for the table. Valid values are "hover",
             "single_checkbox", "multiple_checkbox", "single_row", "multiple_row", and
-            "none". Defaults to "hover".
+            "none". Defaults to "single_row".
         column_options: A dictionary of column configuration options. The keys are
             column names and the values are dictionaries with column options.
         width: The total width of the table widget, in pixels.

--- a/src/inspect_viz/table/_table.py
+++ b/src/inspect_viz/table/_table.py
@@ -17,19 +17,19 @@ class Column(BaseModel):
         align: Text alignment for the column. Valid values are "left", "right",
             "center", and "justify". By default, numbers are right-aligned and other
             values are left-aligned.
+        format: Format string for column values. Use d3-format for numeric columns or
+            d3-time-format for datetime columns.
         width: Column width in pixels.
+        min_width: Minimum column width in pixels.
+        max_width: Maximum column width in pixels.
         flex: The flex value of the table widget, used to determine how much space it
             should take relative to other widgets in a layout. If specified, width is
             ignored.
+        auto_height: Whether the column cell height is automatically adjusted based on
+            content.
         sortable: Whether sorting is enabled for this column.
         filterable: Whether filtering is enabled for this column.
         resizable: Whether the column width can be adjusted by the user.
-        min_width: Minimum column width in pixels.
-        max_width: Maximum column width in pixels.
-        format: Format string for column values. Use d3-format for numeric columns or
-            d3-time-format for datetime columns.
-        auto_height: Whether the column cell height is automatically adjusted based on
-            content.
         wrap_text: Whether the column text is wrapped to fit within the cell.
         header_align: Text alignment for the column header. Valid values are "left",
             "right", "center", and "justify". By default, left aligned.
@@ -64,9 +64,9 @@ class Column(BaseModel):
         align: Literal["left", "right", "center", "justify"] | None = None,
         format: str | None = None,
         width: float | None = None,
-        flex: float | None = None,
         min_width: float | None = None,
         max_width: float | None = None,
+        flex: float | None = None,
         auto_height: bool | None = None,
         sortable: bool | None = None,
         filterable: bool | None = None,
@@ -107,9 +107,6 @@ class Pagination(BaseModel):
             selector with custom list of possible page sizes. Set to true to show the
             page size selector with the default page sizes [20, 50, 100]. Set to false
             to hide the page size selector.
-        auto_page_size: If true, the number of rows to load per page is automatically
-            adjusted by the grid so each page shows enough rows to just fill the area
-            designated for the grid. If false, page_size is used.
     """
 
     page_size: int | Literal["auto"] | None = None
@@ -130,17 +127,9 @@ class Pagination(BaseModel):
 def table(
     data: Data,
     *,
-    filter_by: Selection | None = None,
     columns: list[str | Column] | None = None,
+    filter_by: Selection | None = None,
     target: Selection | None = None,
-    width: float | None = None,
-    max_width: float | None = None,
-    height: float | None = None,
-    sorting: bool | None = None,
-    filtering: bool | Literal["header", "row"] | None = None,
-    pagination: bool | Pagination | None = None,
-    header_height: float | None = None,
-    row_height: float | None = None,
     select: Literal[
         "hover",
         "single_row",
@@ -150,24 +139,32 @@ def table(
         "none",
     ]
     | None = None,
+    width: float | None = None,
+    max_width: float | None = None,
+    height: float | None = None,
+    header_height: float | None = None,
+    row_height: float | None = None,
+    sorting: bool | None = None,
+    filtering: bool | Literal["header", "row"] | None = None,
+    pagination: bool | Pagination | None = None,
 ) -> Component:
     """Tabular display of data.
 
     Args:
         data: The data source for the table.
-        filter_by: Selection to filter by (defaults to data source selection).
         columns: A list of column names to include in the table grid. If unspecified,
             all table columns are included.
+        filter_by: Selection to filter by (defaults to data source selection).
         target: The output selection. A selection clause of the form column IN (rows)
             will be added to the selection for each currently selected table row.
         select: The type of selection to use for the table. Valid values are "hover",
             "single_checkbox", "multiple_checkbox", "single_row", "multiple_row", and
             "none". Defaults to "single_row".
-        column_options: A dictionary of column configuration options. The keys are
-            column names and the values are dictionaries with column options.
         width: The total width of the table widget, in pixels.
         max_width: The maximum width of the table widget, in pixels.
         height: The height of the table widget, in pixels (defaults to 380).
+        header_height: The height of the table header, in pixels.
+        row_height: The height of each table row, in pixels.
         sorting: Set whether sorting columns is enabled.
         filtering: Enable filtering. If set to 'header' a filter button is shown in
             the table header. If set to 'row', a filter is shown in a row beneath the
@@ -175,8 +172,6 @@ def table(
         pagination: Enable pagination. If set to True, default pagination settings
             are used. If set to a Pagination object, custom pagination settings are
             used.
-        header_height: The height of the table header, in pixels.
-        row_height: The height of each table row, in pixels.
     """
     config: dict[str, JsonValue] = dict_remove_none(
         {


### PR DESCRIPTION
- remove select-all
- improve python ergonomics
- default selection to single-row
- improve pagination options
- cleanup docstrings
- introduce column function
- improve table height behavior (380px by default, will fill 'cards' in dashboards)
- map quarto themes onto grid