### PR TITLE
Table Grouping

### DIFF
--- a/docs/table.qmd
+++ b/docs/table.qmd
@@ -147,21 +147,21 @@ table(penguins, columns=[
 
 Default formats for values are as follows:
 
-+--------------+-----------------------+
-| type         | format                |
-+==============+=======================+
-| `integer`    | `','`                 |
-+--------------+-----------------------+
-| `number`\    | `',.2~f'`             |
-| `float`      |                       |
-+--------------+-----------------------+
-| `decimal`    | `',.4~f'`             |
-+--------------+-----------------------+
-| `date`       | `'%Y-%m-%d'`          |
-+--------------+-----------------------+
-| `datetime`\  | `'%Y-%m-%d %H:%M:%S'` |
-| `timestamp`  |                       |
-+--------------+-----------------------+
++---------------+-----------------------+
+| type          | format                |
++===============+=======================+
+| `integer`     | `','`                 |
++---------------+-----------------------+
+| `number`\     | `',.2~f'`             |
+| `float`       |                       |
++---------------+-----------------------+
+| `decimal`     | `',.4~f'`             |
++---------------+-----------------------+
+| `date`        | `'%Y-%m-%d'`          |
++---------------+-----------------------+
+| `datetime`\   | `'%Y-%m-%d %H:%M:%S'` |
+| `timestamp`   |                       |
++---------------+-----------------------+
 
 ### Text Wrapping
 
@@ -243,9 +243,9 @@ table(penguins, columns=[
 
 #### Filter Location
 
-You can control where in the table filters appear by passing other `header` or `row` as the value for filter. `header` places in the filter as buttons in the header row next to the header text. `row` creates` a separate row with inline filter UI for filtering columns. For example:
+You can control where in the table filters appear by passing other `header` or `row` as the value for filter. `header` places in the filter as buttons in the header row next to the header text. `row` creates\` a separate row with inline filter UI for filtering columns. For example:
 
-```python
+``` python
 table(penguins, filtering='row')
 ```
 
@@ -295,6 +295,38 @@ table(penguins,
       pagination=Pagination(page_size=20, page_size_selector=[20,40,60]))
 ```
 
+## Grouping
+
+When displaying tabular data, it can be useful to group the data by specific fields. For example, to display a table with the average attributes of male and female penguins based upon their species, you can using grouping function for some columns:
+
+```{python}
+from inspect_viz.transform import avg, count
+table(penguins, 
+      height=120,
+      columns=[
+        column("species"), 
+        column(avg("body_mass")),
+        column(avg("flipper_length"))])
+```
+
+When providing transforms to apply to columns (e.g. `avg`, `sum`), columns without aggregating transforms will be treated as columns to group by. So in the above example, the table is grouped by `species` displaying the rest of the values using their aggregate values.
+
+## Literal Data
+
+You can also pass literal values (an `int | float | bool`) as a column by passing one or more values as the `column` itself. For example:
+
+```{python}
+table(penguins, 
+      columns=[
+        column([1,2,3,4,5,6,7,8,9], label="sample_bucket"),
+        column("species"), 
+        column("body_mass"),
+        column("flipper_length")])
+        
+```
+
+If a single value is passed, that value will be repeated for every row in the dataset. If a list of values is passed, each row will increment through the list and include the value from the row index. If the list is shorter than the dataset, values will be repeated by repeatedly iterating through the list.
+
 ## Selection
 
 By default, the table will display the selection provided by the data source. If you'd like, you can provide an alternative selection by using `filter_by`.
@@ -312,13 +344,19 @@ table(penguins,
 
 You can use the `select` option to control how selection works within the table. By default, `select` is set to `single_row` which will allow selection of one row at a time by clicking the row. Other options are listed below:
 
-| Option | Action |
-|----|----|
-| `hover` | The selection will be updated when the user's mouse hovers over a row. |
-| `single_row` | The selection will be updated when a single row is selected. The selected row will be highlighted. |
-| `multiple_row` | The selection will be updated when one or more rows are selected. The selected rows will be highlighted. |
-| `single_row_checkbox` | The selection will be updated when a single row is selected using a checkbox. |
-| `multiple_row_checkbox` | The selection will be updated when one or more rows is selected using a checkbox. |
++----------------------------------+----------------------------------------------------------------------------------------------------------+
+| Option                           | Action                                                                                                   |
++==================================+==========================================================================================================+
+| `hover`                          | The selection will be updated when the user's mouse hovers over a row.                                   |
++----------------------------------+----------------------------------------------------------------------------------------------------------+
+| `single_row`                     | The selection will be updated when a single row is selected. The selected row will be highlighted.       |
++----------------------------------+----------------------------------------------------------------------------------------------------------+
+| `multiple_row`                   | The selection will be updated when one or more rows are selected. The selected rows will be highlighted. |
++----------------------------------+----------------------------------------------------------------------------------------------------------+
+| `single_row_checkbox`            | The selection will be updated when a single row is selected using a checkbox.                            |
++----------------------------------+----------------------------------------------------------------------------------------------------------+
+| `multiple_row_checkbox`          | The selection will be updated when one or more rows is selected using a checkbox.                        |
++----------------------------------+----------------------------------------------------------------------------------------------------------+
 
 ## Appearance
 
@@ -344,32 +382,45 @@ table(penguins,
 
 Using the three following basic color options will provide new colors for the table (with the overall colors of the table derived from these three themes). Each of these colors accepts a `css` color value (for example a hex color string or a named value like `red`).
 
-| Option | Target |
-|----|----|
-| `background_color` | The background color use for cells. |
-| `foreground_color` | The foreground color used for values within cells. |
-| `accent_color` | Accent color used for things like selection and highlights. |
++----------------------------------+-------------------------------------------------------------+
+| Option                           | Target                                                      |
++==================================+=============================================================+
+| `background_color`               | The background color use for cells.                         |
++----------------------------------+-------------------------------------------------------------+
+| `foreground_color`               | The foreground color used for values within cells.          |
++----------------------------------+-------------------------------------------------------------+
+| `accent_color`                   | Accent color used for things like selection and highlights. |
++----------------------------------+-------------------------------------------------------------+
 
 ### More Color Options
 
 In addition to the previous basic options, you can do further customization of the colors by passing a `css` color value to the following:
 
-| Option | Target |
-|----|----|
-| `text_color` | The text color for UI elements presented within the table. |
-| `header_text_color` | The color for text in the header row. |
-| `cell_text_color` | The color for text in cell within the body of the table. |
-| `selected_row_background_color` | The background color of selected rows. |
++----------------------------------+------------------------------------------------------------+
+| Option                           | Target                                                     |
++==================================+============================================================+
+| `text_color`                     | The text color for UI elements presented within the table. |
++----------------------------------+------------------------------------------------------------+
+| `header_text_color`              | The color for text in the header row.                      |
++----------------------------------+------------------------------------------------------------+
+| `cell_text_color`                | The color for text in cell within the body of the table.   |
++----------------------------------+------------------------------------------------------------+
+| `selected_row_background_color`  | The background color of selected rows.                     |
++----------------------------------+------------------------------------------------------------+
 
 ### Fonts
 
 You can control the fonts used by the table by passing a `css` `font-family` value in the following options:
 
++----------------------+------------------------------------------------------+
 | Option               | Target                                               |
-|----------------------|------------------------------------------------------|
++======================+======================================================+
 | `font_family`        | The default font for all text within the table.      |
++----------------------+------------------------------------------------------+
 | `header_font_family` | The font used for text within the header row.        |
++----------------------+------------------------------------------------------+
 | `cell_font_family`   | The font used for text within the body of the table. |
++----------------------+------------------------------------------------------+
 
 ### Border
 

--- a/js/inputs/table.ts
+++ b/js/inputs/table.ts
@@ -1,6 +1,5 @@
 import {
     clausePoints,
-    FieldInfo,
     isSelection,
     queryFieldInfo,
     throttle,
@@ -30,6 +29,7 @@ import {
     SelectQuery,
     sql,
     column,
+    avg,
 } from 'https://cdn.jsdelivr.net/npm/@uwdata/mosaic-sql@0.16.2/+esm';
 
 import {
@@ -55,9 +55,54 @@ import * as d3TimeFormat from 'https://cdn.jsdelivr.net/npm/d3-time-format@4.1.0
 import { Input, InputOptions } from './input';
 import { generateId } from '../util/id';
 import { JSType } from '@uwdata/mosaic-core';
+import { AggregateNode, ExprValue } from '@uwdata/mosaic-sql';
+
+// TODO: table options not working for literals (probably column naming issue)
+// TODO: implement all aggregate function types
+// TODO: deal with filtering for literals (probably need to make them unfilterable / unsortable or allow the grid itself to do the sorting and filtering) could fall back to old hacky way of shutting down filtering for columns and just leave filtering enabled for the literal columns
+// TODO: deal with sorting of literals
+
+type Transform = Record<string, any>;
+
+type Channel = string | Transform | boolean | number | undefined | Array<boolean | number>;
+
+// A column which has been resolved with user provided information
+type ResolvedColumn = ResolvedSimpleColumn | ResolvedLiteralColumn | ResolvedAggregateColumn;
+
+// Resolved Column adds additional information to the Column type
+// based upon the raw column specifiction provided by the user, including
+// any aggregatinon behavior.
+export interface BaseResolvedColumn extends Column {
+    // The column name as it will be used in the query (e.g. the alias for the column)
+    // This could be synthesized if this is an aggregation or literal.
+    column_name: string;
+}
+
+// A column which contains one or more literal values
+export interface ResolvedLiteralColumn extends BaseResolvedColumn {
+    type: 'literal';
+}
+
+// A column which contains an aggregate expression
+export interface ResolvedAggregateColumn extends BaseResolvedColumn {
+    // The actual column name in the database
+    column_id: string;
+
+    // The aggregate expression and its arguments, if this column is an aggregation.
+    agg_expr: string;
+    agg_expr_args: ExprValue[];
+
+    type: 'aggregate';
+}
+// A column which is a simple column reference in the database.
+export interface ResolvedSimpleColumn extends BaseResolvedColumn {
+    // The actual column name in the database
+    column_id: string;
+    type: 'column';
+}
 
 export interface Column {
-    column: string;
+    column: Channel;
     label?: string;
     align?: 'left' | 'right' | 'center' | 'justify';
     format?: string;
@@ -128,15 +173,15 @@ interface ColSortModel {
 
 export class Table extends Input {
     private readonly id_: string;
-    private readonly columns_: Column[];
+    private readonly columns_: ResolvedColumn[];
     private readonly columnOptions_: Record<string, Column>;
+    private readonly columnTypes_: Record<string, JSType> = {};
     private readonly height_: number | undefined;
 
     private readonly gridContainer_: HTMLDivElement;
     private grid_: GridApi | null = null;
     private gridOptions_: GridOptions;
 
-    private schema_: FieldInfo[];
     private currentRow_: number;
     private sortModel_: ColSortModel[] = [];
     private filterModel_: FilterModel = {};
@@ -159,7 +204,7 @@ export class Table extends Input {
         this.columns_ = resolveColumns(this.options_.columns || ['*']);
         this.columnOptions_ = this.columns_.reduce(
             (acc, col) => {
-                acc[col.column] = col;
+                acc[col.column_name] = col;
                 return acc;
             },
             {} as Record<string, Column>
@@ -168,7 +213,6 @@ export class Table extends Input {
 
         // state
         this.currentRow_ = -1;
-        this.schema_ = [];
 
         // height and width
         this.element.classList.add('inspect-viz-table');
@@ -221,7 +265,10 @@ export class Table extends Input {
 
     // contribute a selection clause back to the target selection
     clause(rows: number[] = []) {
-        const fields = this.schema_.map(s => s.column);
+        // TODO: handle literals and aggregates
+        const nonLiteralColumns = this.columns_.filter(col => col.type !== 'literal');
+        const fields = nonLiteralColumns.map(column => column.column_id);
+
         const values = rows.map(row => {
             return fields.map(f => this.data_.columns[f][row]);
         });
@@ -233,13 +280,46 @@ export class Table extends Input {
     async prepare() {
         // query for column schema information
         const table = this.options_.from;
-        const fields = this.columns_.map(column => ({ column: column.column, table }));
-        this.schema_ = await queryFieldInfo(this.coordinator!, fields);
+        const nonLiteralCols = this.columns_.filter(col => col.type !== 'literal');
+        const fields = nonLiteralCols.map(column => ({ column: column.column_id!, table }));
+
+        // Query the schema and resolve the column types
+        const schema = await queryFieldInfo(this.coordinator!, fields);
+        schema.forEach(({ column, type }) => {
+            const col = nonLiteralCols.find(c => c.column_id === column);
+            if (col) {
+                this.columnTypes_[col?.column_name] = type as JSType;
+            }
+        });
+
+        // For literals, we need to determine their types based on the values provided.
+        const literalCols = this.columns_.filter(col => col.type === 'literal');
+        literalCols.forEach(c => {
+            const colVal = c.column;
+            if (Array.isArray(colVal)) {
+                // Peek at the first element to determine the type
+                const firstVal = colVal[0];
+                const typeStr =
+                    typeof firstVal === 'boolean'
+                        ? 'boolean'
+                        : typeof firstVal === 'number'
+                          ? 'number'
+                          : undefined;
+                if (typeStr) {
+                    this.columnTypes_[c.column_name] = typeStr as JSType;
+                }
+            } else if (typeof colVal === 'boolean') {
+                this.columnTypes_[c.column_name] = 'boolean';
+            } else if (typeof colVal === 'number') {
+                this.columnTypes_[c.column_name] = 'number';
+            }
+        });
 
         // create column definitions for ag-grid
-        const columnDefs: ColDef[] = this.schema_.map(({ column, type }) =>
-            this.createColumnDef(column, type)
-        );
+        const columnDefs: ColDef[] = this.columns_.map(column => {
+            const t = this.columnTypes_[column.column_name];
+            return this.createColumnDef(column.column_name, t);
+        });
         this.gridOptions_.columnDefs = columnDefs;
 
         // create the grid
@@ -249,20 +329,51 @@ export class Table extends Input {
     // mosaic calls this every time it needs to show data to find
     // out what query we want to run
     query(filter: FilterExpr[] = []) {
+        const selectItems: Record<string, ExprNode | string> = {};
+        const groupBy: string[] = [];
+        let has_aggregate = false;
+
+        // Go through each column and determine the select item
+        // for the column. Some columns may not have items because
+        // they are providing a literal or list of literals.
+        const nonLiteralCols = this.columns_.filter(col => col.type !== 'literal');
+        for (const column of nonLiteralCols) {
+            if (column.type === 'aggregate') {
+                const item = aggregateExpression(column);
+                selectItems[item[0]] = item[1];
+                has_aggregate = true;
+            } else {
+                selectItems[column.column_id] = column.column_id;
+                groupBy.push(column.column_id);
+            }
+        }
+
         // Select the columns
         let query = Query.from(this.options_.from).select(
-            this.schema_.length ? this.schema_.map(s => s.column) : '*'
+            Object.keys(selectItems).length ? selectItems : '*'
         );
+
+        // Group by non aggregated columns
+        if (has_aggregate && groupBy.length > 0) {
+            query.groupby(groupBy);
+        }
 
         // apply the external filter
         query = query.where(...filter);
 
         // apply the filter model
-        Object.keys(this.filterModel_).forEach(colId => {
-            const filter = this.filterModel_[colId] as SupportedFilter;
-            const expression = filterExpression(colId, filter, query);
+        Object.keys(this.filterModel_).forEach(columnName => {
+            const col = this.columns_.find(c => c.column_name === columnName);
+
+            const useHaving = col?.type === 'aggregate';
+            const filter = this.filterModel_[columnName] as SupportedFilter;
+            const expression = filterExpression(columnName, filter, query);
             if (expression) {
-                query = query.where(expression);
+                if (useHaving) {
+                    query.having(expression);
+                } else {
+                    query = query.where(expression);
+                }
             }
         });
 
@@ -295,9 +406,17 @@ export class Table extends Input {
         const rowData: any[] = [];
         for (let i = 0; i < this.data_.numRows; i++) {
             const row: any = {};
-            this.schema_.forEach(({ column }) => {
-                row[column] = this.data_.columns[column][i];
+            this.columns_.forEach(({ column_name, column }) => {
+                if (Array.isArray(column)) {
+                    const index = i % column.length;
+                    row[column_name] = column[index];
+                } else if (typeof column === 'boolean' || typeof column === 'number') {
+                    row[column_name] = column;
+                } else {
+                    row[column_name] = this.data_.columns[column_name][i];
+                }
             });
+
             rowData.push(row);
         }
 
@@ -329,8 +448,6 @@ export class Table extends Input {
             borderRadius: this.options_.style?.border_radius,
 
             selectedRowBackgroundColor: this.options_.style?.selected_row_background_color,
-
-            //borderWidth: this.options_.style?.border_width,
         });
 
         // initialize grid options
@@ -409,7 +526,6 @@ export class Table extends Input {
             },
         };
     }
-
     private createColumnDef(column: string, type: JSType): ColDef {
         const columnOptions = this.columnOptions_[column] || {};
 
@@ -495,12 +611,73 @@ export class Table extends Input {
     }
 }
 
-const resolveColumns = (columns: Array<string | Column>): Column[] => {
+const resolveColumns = (columns: Array<string | Column>): ResolvedColumn[] => {
+    let columnCount = 1;
+    const incrementedColumnName = () => {
+        return `col_${columnCount++}`;
+    };
+
     return columns.map(col => {
         if (typeof col === 'string') {
-            return { column: col };
+            // Column is just a column id
+            return {
+                column_name: col,
+                column_id: col,
+                column: col,
+                type: 'column',
+            };
         } else if (typeof col === 'object' && col !== null) {
-            return col as Column;
+            // Column is an object (a Column), we need to parse the column
+            // property to properly resolve it
+            if (typeof col.column === 'string') {
+                return {
+                    ...col,
+                    column_name: col.column,
+                    column_id: col.column,
+                    type: 'column',
+                };
+            } else if (typeof col.column === 'number') {
+                // If the column is a number, treat it as an index
+                // It has no column_id since it isn't in the database - we generate
+                // a display alias for it
+                return {
+                    column_name: incrementedColumnName(),
+                    column: col.column,
+                    type: 'literal',
+                };
+            } else if (typeof col.column === 'boolean') {
+                // If the column is a boolean, treat it as a flag
+                // It has no column_id since it isn't in the database - we generate
+                // a display alias for it
+                return {
+                    column_name: incrementedColumnName(),
+                    column: col.column,
+                    type: 'literal',
+                };
+            } else if (Array.isArray(col.column)) {
+                // peek at the first element to determine the type
+                if (col.column.length === 0) {
+                    throw new Error('Empty array column is not supported');
+                }
+                return {
+                    column_name: incrementedColumnName(),
+                    column: col.column,
+                    type: 'literal',
+                };
+            } else if (typeof col.column === 'object') {
+                const agg = Object.keys(col.column)[0];
+                const targetColumn = col.column[agg];
+                return {
+                    ...col,
+                    column_name: `${agg}_${targetColumn}`,
+                    column_id: targetColumn,
+                    agg_expr: agg,
+                    agg_expr_args: [targetColumn],
+                    type: 'aggregate',
+                };
+            } else {
+                throw new Error('Unsupported column type: ' + typeof col.column);
+            }
         } else {
             throw new Error(`Invalid column definition: ${col}`);
         }
@@ -684,6 +861,12 @@ export const simpleExpression = (
             console.warn(`Unsupported filter type: ${type}`);
     }
     return undefined;
+};
+
+const aggregateExpression = (
+    c: ResolvedAggregateColumn
+): [alias: string, aggregate: AggregateNode] => {
+    return [c.column_name, avg(c.agg_expr_args[0] as ExprValue)];
 };
 
 const isCombinedSimpleModel = (

--- a/js/inputs/table.ts
+++ b/js/inputs/table.ts
@@ -1,5 +1,6 @@
 import {
     clausePoints,
+    FieldInfo,
     isSelection,
     queryFieldInfo,
     throttle,
@@ -202,9 +203,9 @@ interface ColSortModel {
 
 export class Table extends Input {
     private readonly id_: string;
-    private readonly columns_: ResolvedColumn[];
-    private readonly columnsByName_: Record<string, ResolvedColumn>;
-    private readonly columnTypes_: Record<string, JSType> = {};
+    private columns_: ResolvedColumn[] | null = null;
+    private columnsByName_: Record<string, ResolvedColumn> | null = null;
+    private columnTypes_: Record<string, JSType> = {};
     private readonly height_: number | undefined;
 
     private readonly gridContainer_: HTMLDivElement;
@@ -229,24 +230,14 @@ export class Table extends Input {
         // id
         this.id_ = generateId();
 
-        // defaults
-        this.columns_ = resolveColumns(this.options_.columns || ['*']);
-
-        this.columnsByName_ = this.columns_.reduce(
-            (acc, col) => {
-                acc[col.column_name] = col;
-                return acc;
-            },
-            {} as Record<string, ResolvedColumn>
-        );
-
-        this.height_ = this.options_.height;
-
         // state
         this.currentRow_ = -1;
 
-        // height and width
+        // class decoration
         this.element.classList.add('inspect-viz-table');
+
+        // height and width
+        this.height_ = this.options_.height;
         if (typeof this.options_.width === 'number') {
             this.element.style.width = `${this.options_.width}px`;
         }
@@ -307,17 +298,27 @@ export class Table extends Input {
     // mosaic calls this and initialization to let us fetch the schema
     // and do related setup
     async prepare() {
-        // query for column schema information
+        // query available columns from the database
         const table = this.options_.from;
-        const fields = this.getDatabaseColumns().map(column => ({
-            column: column.column_id!,
-            table,
-        }));
+        const schema = await queryFieldInfo(this.coordinator!, [{ column: '*', table }]);
+
+        // Resolve the columns using either the user provided columns or all
+        // the fields in the schema
+        const userColumns = this.options_.columns
+            ? this.options_.columns
+            : schema.map(f => f.column);
+        this.columns_ = resolveColumns(userColumns);
+        this.columnsByName_ = this.columns_.reduce(
+            (acc, col) => {
+                acc[col.column_name] = col;
+                return acc;
+            },
+            {} as Record<string, ResolvedColumn>
+        );
 
         // For each non-literal column, we need to resolve the type
         // Do this by using the schema query to get column types and use the
         // column type as the type (even for aggregate columns  )
-        const schema = await queryFieldInfo(this.coordinator!, fields);
         this.columns_
             .filter(c => c.type !== 'literal')
             .forEach(column => {
@@ -396,6 +397,10 @@ export class Table extends Input {
 
         // apply the filter model
         Object.keys(this.filterModel_).forEach(columnName => {
+            if (!this.columnsByName_) {
+                throw new Error('Columns not resolved yet. Please call prepare() first.');
+            }
+
             const col = this.columnsByName_[columnName];
             if (col.type !== 'literal') {
                 const useHaving = col?.type === 'aggregate';
@@ -414,6 +419,10 @@ export class Table extends Input {
         // Apply sorting
         if (this.sortModel_.length > 0) {
             this.sortModel_.forEach(sort => {
+                if (!this.columnsByName_) {
+                    throw new Error('Columns not resolved yet. Please call prepare() first.');
+                }
+
                 const col = this.columnsByName_[sort.colId];
                 if (col.type !== 'literal') {
                     query = query.orderby(sort.sort === 'asc' ? asc(sort.colId) : desc(sort.colId));
@@ -437,7 +446,13 @@ export class Table extends Input {
     }
 
     private updateGrid = throttle(async () => {
-        if (!this.grid_) return;
+        if (!this.grid_) {
+            return;
+        }
+
+        if (!this.columns_) {
+            throw new Error('Columns not resolved yet. Please call prepare() first.');
+        }
 
         // convert column-based data to row-based data for ag-grid
         const rowData: any[] = [];
@@ -568,14 +583,26 @@ export class Table extends Input {
     }
 
     private getLiteralColumns(): ResolvedLiteralColumn[] {
+        if (!this.columns_) {
+            throw new Error('Columns not resolved yet. Please call prepare() first.');
+        }
+
         return this.columns_.filter(c => c.type === 'literal');
     }
 
     private getDatabaseColumns(): Array<ResolvedSimpleColumn | ResolvedAggregateColumn> {
+        if (!this.columns_) {
+            throw new Error('Columns not resolved yet. Please call prepare() first.');
+        }
+
         return this.columns_.filter(c => c.type === 'column' || c.type === 'aggregate');
     }
 
     private createColumnDef(column_name: string, type: JSType): ColDef {
+        if (!this.columnsByName_) {
+            throw new Error('Columns not resolved yet. Please call prepare() first.');
+        }
+
         const column = this.columnsByName_[column_name] || {};
 
         // Align, numbers right aligned by default
@@ -664,6 +691,10 @@ export class Table extends Input {
         const columns = this.grid_.getColumns();
         if (columns) {
             columns.forEach(async column => {
+                if (!this.columnsByName_) {
+                    throw new Error('Columns not resolved yet. Please call prepare() first.');
+                }
+
                 const colId = column.getColId();
                 const filterInstance = await this.grid_!.getColumnFilterInstance(colId);
                 const col = this.columnsByName_[colId];

--- a/js/inputs/table.ts
+++ b/js/inputs/table.ts
@@ -30,6 +30,40 @@ import {
     sql,
     column,
     avg,
+    count,
+    sum,
+    argmax,
+    mad,
+    max,
+    min,
+    product,
+    geomean,
+    median,
+    mode,
+    variance,
+    stddev,
+    skewness,
+    kurtosis,
+    entropy,
+    varPop,
+    stddevPop,
+    first,
+    last,
+    stringAgg,
+    arrayAgg,
+    argmin,
+    quantile,
+    corr,
+    covarPop,
+    regrIntercept,
+    regrSlope,
+    regrCount,
+    regrR2,
+    regrSXX,
+    regrSYY,
+    regrSXY,
+    regrAvgX,
+    regrAvgY,
 } from 'https://cdn.jsdelivr.net/npm/@uwdata/mosaic-sql@0.16.2/+esm';
 
 import {
@@ -56,11 +90,6 @@ import { Input, InputOptions } from './input';
 import { generateId } from '../util/id';
 import { JSType } from '@uwdata/mosaic-core';
 import { AggregateNode, ExprValue } from '@uwdata/mosaic-sql';
-
-// TODO: table options not working for literals (probably column naming issue)
-// TODO: implement all aggregate function types
-// TODO: deal with filtering for literals (probably need to make them unfilterable / unsortable or allow the grid itself to do the sorting and filtering) could fall back to old hacky way of shutting down filtering for columns and just leave filtering enabled for the literal columns
-// TODO: deal with sorting of literals
 
 type Transform = Record<string, any>;
 
@@ -174,7 +203,7 @@ interface ColSortModel {
 export class Table extends Input {
     private readonly id_: string;
     private readonly columns_: ResolvedColumn[];
-    private readonly columnOptions_: Record<string, Column>;
+    private readonly columnsByName_: Record<string, ResolvedColumn>;
     private readonly columnTypes_: Record<string, JSType> = {};
     private readonly height_: number | undefined;
 
@@ -202,13 +231,15 @@ export class Table extends Input {
 
         // defaults
         this.columns_ = resolveColumns(this.options_.columns || ['*']);
-        this.columnOptions_ = this.columns_.reduce(
+
+        this.columnsByName_ = this.columns_.reduce(
             (acc, col) => {
                 acc[col.column_name] = col;
                 return acc;
             },
-            {} as Record<string, Column>
+            {} as Record<string, ResolvedColumn>
         );
+
         this.height_ = this.options_.height;
 
         // state
@@ -265,9 +296,7 @@ export class Table extends Input {
 
     // contribute a selection clause back to the target selection
     clause(rows: number[] = []) {
-        // TODO: handle literals and aggregates
-        const nonLiteralColumns = this.columns_.filter(col => col.type !== 'literal');
-        const fields = nonLiteralColumns.map(column => column.column_id);
+        const fields = this.getDatabaseColumns().map(column => column.column_id);
 
         const values = rows.map(row => {
             return fields.map(f => this.data_.columns[f][row]);
@@ -280,21 +309,26 @@ export class Table extends Input {
     async prepare() {
         // query for column schema information
         const table = this.options_.from;
-        const nonLiteralCols = this.columns_.filter(col => col.type !== 'literal');
-        const fields = nonLiteralCols.map(column => ({ column: column.column_id!, table }));
+        const fields = this.getDatabaseColumns().map(column => ({
+            column: column.column_id!,
+            table,
+        }));
 
-        // Query the schema and resolve the column types
+        // For each non-literal column, we need to resolve the type
+        // Do this by using the schema query to get column types and use the
+        // column type as the type (even for aggregate columns  )
         const schema = await queryFieldInfo(this.coordinator!, fields);
-        schema.forEach(({ column, type }) => {
-            const col = nonLiteralCols.find(c => c.column_id === column);
-            if (col) {
-                this.columnTypes_[col?.column_name] = type as JSType;
-            }
-        });
+        this.columns_
+            .filter(c => c.type !== 'literal')
+            .forEach(column => {
+                const item = schema.find(s => s.column === column.column_id);
+                if (item) {
+                    this.columnTypes_[column.column_name] = item.type as JSType;
+                }
+            });
 
         // For literals, we need to determine their types based on the values provided.
-        const literalCols = this.columns_.filter(col => col.type === 'literal');
-        literalCols.forEach(c => {
+        this.getLiteralColumns().forEach(c => {
             const colVal = c.column;
             if (Array.isArray(colVal)) {
                 // Peek at the first element to determine the type
@@ -336,13 +370,12 @@ export class Table extends Input {
         // Go through each column and determine the select item
         // for the column. Some columns may not have items because
         // they are providing a literal or list of literals.
-        const nonLiteralCols = this.columns_.filter(col => col.type !== 'literal');
-        for (const column of nonLiteralCols) {
+        for (const column of this.getDatabaseColumns()) {
             if (column.type === 'aggregate') {
                 const item = aggregateExpression(column);
                 selectItems[item[0]] = item[1];
                 has_aggregate = true;
-            } else {
+            } else if (column.type === 'column') {
                 selectItems[column.column_id] = column.column_id;
                 groupBy.push(column.column_id);
             }
@@ -363,16 +396,17 @@ export class Table extends Input {
 
         // apply the filter model
         Object.keys(this.filterModel_).forEach(columnName => {
-            const col = this.columns_.find(c => c.column_name === columnName);
-
-            const useHaving = col?.type === 'aggregate';
-            const filter = this.filterModel_[columnName] as SupportedFilter;
-            const expression = filterExpression(columnName, filter, query);
-            if (expression) {
-                if (useHaving) {
-                    query.having(expression);
-                } else {
-                    query = query.where(expression);
+            const col = this.columnsByName_[columnName];
+            if (col.type !== 'literal') {
+                const useHaving = col?.type === 'aggregate';
+                const filter = this.filterModel_[columnName] as SupportedFilter;
+                const expression = filterExpression(columnName, filter, query);
+                if (expression) {
+                    if (useHaving) {
+                        query.having(expression);
+                    } else {
+                        query = query.where(expression);
+                    }
                 }
             }
         });
@@ -380,7 +414,10 @@ export class Table extends Input {
         // Apply sorting
         if (this.sortModel_.length > 0) {
             this.sortModel_.forEach(sort => {
-                query = query.orderby(sort.sort === 'asc' ? asc(sort.colId) : desc(sort.colId));
+                const col = this.columnsByName_[sort.colId];
+                if (col.type !== 'literal') {
+                    query = query.orderby(sort.sort === 'asc' ? asc(sort.colId) : desc(sort.colId));
+                }
             });
         }
 
@@ -453,7 +490,6 @@ export class Table extends Input {
         // initialize grid options
         return {
             // always pass filter to allow server-side filtering
-            alwaysPassFilter: () => true,
             pagination: !!options.pagination,
             paginationAutoPageSize:
                 options.pagination?.page_size === 'auto' ||
@@ -463,7 +499,7 @@ export class Table extends Input {
                 typeof options.pagination?.page_size === 'number'
                     ? options.pagination.page_size
                     : undefined,
-            animateRows: true,
+            animateRows: false,
             headerHeight: headerHeightPixels,
             rowHeight: options.row_height,
             columnDefs: [],
@@ -524,51 +560,67 @@ export class Table extends Input {
                     this.options_.as.update(this.clause());
                 }
             },
+            onGridReady: () => {
+                // When the grid is ready, we can update it with the initial data
+                this.patchGrid();
+            },
         };
     }
-    private createColumnDef(column: string, type: JSType): ColDef {
-        const columnOptions = this.columnOptions_[column] || {};
+
+    private getLiteralColumns(): ResolvedLiteralColumn[] {
+        return this.columns_.filter(c => c.type === 'literal');
+    }
+
+    private getDatabaseColumns(): Array<ResolvedSimpleColumn | ResolvedAggregateColumn> {
+        return this.columns_.filter(c => c.type === 'column' || c.type === 'aggregate');
+    }
+
+    private createColumnDef(column_name: string, type: JSType): ColDef {
+        const column = this.columnsByName_[column_name] || {};
 
         // Align, numbers right aligned by default
-        const align = columnOptions.align || (type === 'number' ? 'right' : 'left');
-        const headerAlignment = columnOptions.header_align;
+        const align = column.align || (type === 'number' ? 'right' : 'left');
+        const headerAlignment = column.header_align;
 
         // Format string
-        const formatter = formatterForType(type, columnOptions.format);
+        const formatter = formatterForType(type, column.format);
 
         // Sorting / filtering
-        const sortable = this.options_.sorting !== false && columnOptions.sortable !== false;
-        const filterable = this.options_.filtering !== false && columnOptions.filterable !== false;
+        const sortable = this.options_.sorting !== false && column.sortable !== false;
+        const filterable = this.options_.filtering !== false && column.filterable !== false;
 
         // Sizing
-        const resizable = columnOptions.resizable !== false;
+        const resizable = column.resizable !== false;
 
         // Min and max width
-        const minWidth = columnOptions.min_width;
-        const maxWidth = columnOptions.max_width;
+        const minWidth = column.min_width;
+        const maxWidth = column.max_width;
 
         // auto height
-        const autoHeight = columnOptions.auto_height;
+        const autoHeight = column.auto_height;
         const autoHeaderHeight =
-            this.options_.header_height === 'auto' && columnOptions.header_auto_height !== false;
+            this.options_.header_height === 'auto' && column.header_auto_height !== false;
 
         // wrap text
-        const wrapText = columnOptions.wrap_text;
-        const wrapHeaderText = columnOptions.header_wrap_text;
+        const wrapText = column.wrap_text;
+        const wrapHeaderText = column.header_wrap_text;
 
         // flex
-        const flex = columnOptions.flex;
+        const flex = column.flex;
+
+        // Disables client side sorting (used for non-literal columns
+        // where the database can handle the sorting)
+        const disableClientSort = (_valueA: unknown, _valueB: unknown) => {
+            return 0;
+        };
 
         // Position the filter below the header
         const colDef: ColDef = {
-            field: column,
-            headerName: columnOptions.label || column,
+            field: column_name,
+            headerName: column.label || column_name,
             headerClass: headerClasses(headerAlignment),
             cellStyle: { textAlign: align },
-            comparator: (_valueA, _valueB) => {
-                // Sorting is handled by the database, so never client sort
-                return 0;
-            },
+            comparator: column.type !== 'literal' ? disableClientSort : undefined,
             filter: !filterable ? false : filterForColumnType(type),
             flex,
             sortable,
@@ -580,7 +632,8 @@ export class Table extends Input {
             wrapText,
             wrapHeaderText,
             floatingFilter: this.options_.filtering === 'row',
-            suppressMovable: true, // Disable column moving
+            // Disable column moving
+            suppressMovable: true,
             valueFormatter: params => {
                 // Format the value if a format is provided
                 const value = params.value;
@@ -593,7 +646,7 @@ export class Table extends Input {
 
         // Set columns widths, if explicitly provided
         // otherwise use flex to make all columns equal
-        const width = columnOptions.width;
+        const width = column.width;
         if (width) {
             colDef.width = width;
         } else if (flex === undefined || flex === null) {
@@ -601,6 +654,34 @@ export class Table extends Input {
         }
 
         return colDef;
+    }
+
+    private patchGrid() {
+        if (!this.grid_) {
+            return;
+        }
+
+        const columns = this.grid_.getColumns();
+        if (columns) {
+            columns.forEach(async column => {
+                const colId = column.getColId();
+                const filterInstance = await this.grid_!.getColumnFilterInstance(colId);
+                const col = this.columnsByName_[colId];
+
+                // This is a workaround to disable client side filtering so we can implement
+                // filtering using the query method instead.
+                //
+                // Since literal columns aren't filtered in the database, we instead
+                // use client side filtering for these
+                if (
+                    filterInstance &&
+                    typeof filterInstance.doesFilterPass === 'function' &&
+                    col.type !== 'literal'
+                ) {
+                    filterInstance.doesFilterPass = () => true;
+                }
+            });
+        }
     }
 
     // all mosaic inputs implement this, not exactly sure what it does
@@ -641,6 +722,7 @@ const resolveColumns = (columns: Array<string | Column>): ResolvedColumn[] => {
                 // It has no column_id since it isn't in the database - we generate
                 // a display alias for it
                 return {
+                    ...col,
                     column_name: incrementedColumnName(),
                     column: col.column,
                     type: 'literal',
@@ -650,6 +732,7 @@ const resolveColumns = (columns: Array<string | Column>): ResolvedColumn[] => {
                 // It has no column_id since it isn't in the database - we generate
                 // a display alias for it
                 return {
+                    ...col,
                     column_name: incrementedColumnName(),
                     column: col.column,
                     type: 'literal',
@@ -660,6 +743,7 @@ const resolveColumns = (columns: Array<string | Column>): ResolvedColumn[] => {
                     throw new Error('Empty array column is not supported');
                 }
                 return {
+                    ...col,
                     column_name: incrementedColumnName(),
                     column: col.column,
                     type: 'literal',
@@ -866,7 +950,100 @@ export const simpleExpression = (
 const aggregateExpression = (
     c: ResolvedAggregateColumn
 ): [alias: string, aggregate: AggregateNode] => {
-    return [c.column_name, avg(c.agg_expr_args[0] as ExprValue)];
+    const aggExpr = c.agg_expr;
+
+    const firstArg = () => {
+        if (c.agg_expr_args.length > 0) {
+            return c.agg_expr_args[0];
+        }
+        throw new Error(`Aggregate expression ${aggExpr} requires at least one argument`);
+    };
+
+    const secondArg = () => {
+        if (c.agg_expr_args.length > 1) {
+            return c.agg_expr_args[1];
+        }
+        throw new Error(`Aggregate expression ${aggExpr} requires at least two arguments`);
+    };
+
+    const r = (val: AggregateNode): [alias: string, aggregate: AggregateNode] => {
+        return [c.column_name, val];
+    };
+
+    switch (aggExpr) {
+        case 'count':
+            return r(count(firstArg()));
+        case 'sum':
+            return r(sum(firstArg()));
+        case 'avg':
+            return r(avg(firstArg()));
+        case 'argmax':
+            return r(argmax(firstArg(), secondArg()));
+        case 'mad':
+            return r(mad(firstArg()));
+        case 'max':
+            return r(max(firstArg()));
+        case 'min':
+            return r(min(firstArg()));
+        case 'product':
+            return r(product(firstArg()));
+        case 'geomean':
+            return r(geomean(firstArg()));
+        case 'median':
+            return r(median(firstArg()));
+        case 'mode':
+            return r(mode(firstArg()));
+        case 'variance':
+            return r(variance(firstArg()));
+        case 'stddev':
+            return r(stddev(firstArg()));
+        case 'skewness':
+            return r(skewness(firstArg()));
+        case 'kurtosis':
+            return r(kurtosis(firstArg()));
+        case 'entropy':
+            return r(entropy(firstArg()));
+        case 'varPop':
+            return r(varPop(firstArg()));
+        case 'stddevPop':
+            return r(stddevPop(firstArg()));
+        case 'first':
+            return r(first(firstArg()));
+        case 'last':
+            return r(last(firstArg()));
+        case 'stringAgg':
+            return r(stringAgg(firstArg()));
+        case 'arrayAgg':
+            return r(arrayAgg(firstArg()));
+        case 'argmin':
+            return r(argmin(firstArg(), secondArg()));
+        case 'quantile':
+            return r(quantile(firstArg(), secondArg()));
+        case 'corr':
+            return r(corr(firstArg(), secondArg()));
+        case 'covarPop':
+            return r(covarPop(firstArg(), secondArg()));
+        case 'regrIntercept':
+            return r(regrIntercept(firstArg(), secondArg()));
+        case 'regrSlope':
+            return r(regrSlope(firstArg(), secondArg()));
+        case 'regrCount':
+            return r(regrCount(firstArg(), secondArg()));
+        case 'regrR2':
+            return r(regrR2(firstArg(), secondArg()));
+        case 'regrSXX':
+            return r(regrSXX(firstArg(), secondArg()));
+        case 'regrSYY':
+            return r(regrSYY(firstArg(), secondArg()));
+        case 'regrSXY':
+            return r(regrSXY(firstArg(), secondArg()));
+        case 'regrAvgX':
+            return r(regrAvgX(firstArg(), secondArg()));
+        case 'regrAvgY':
+            return r(regrAvgY(firstArg(), secondArg()));
+        default:
+            throw new Error(`Unsupported aggregate expression: ${aggExpr}`);
+    }
 };
 
 const isCombinedSimpleModel = (

--- a/src/inspect_viz/_widgets/mosaic.js
+++ b/src/inspect_viz/_widgets/mosaic.js
@@ -691,17 +691,9 @@ var Table = class extends Input {
     this.options_ = options_;
     ModuleRegistry.registerModules([AllCommunityModule]);
     this.id_ = generateId();
-    this.columns_ = resolveColumns(this.options_.columns || ["*"]);
-    this.columnsByName_ = this.columns_.reduce(
-      (acc, col) => {
-        acc[col.column_name] = col;
-        return acc;
-      },
-      {}
-    );
-    this.height_ = this.options_.height;
     this.currentRow_ = -1;
     this.element.classList.add("inspect-viz-table");
+    this.height_ = this.options_.height;
     if (typeof this.options_.width === "number") {
       this.element.style.width = `${this.options_.width}px`;
     }
@@ -739,8 +731,8 @@ var Table = class extends Input {
     this.gridOptions_ = this.createGridOptions(this.options_);
   }
   id_;
-  columns_;
-  columnsByName_;
+  columns_ = null;
+  columnsByName_ = null;
   columnTypes_ = {};
   height_;
   gridContainer_;
@@ -765,11 +757,16 @@ var Table = class extends Input {
   // and do related setup
   async prepare() {
     const table = this.options_.from;
-    const fields = this.getDatabaseColumns().map((column2) => ({
-      column: column2.column_id,
-      table
-    }));
-    const schema = await queryFieldInfo(this.coordinator, fields);
+    const schema = await queryFieldInfo(this.coordinator, [{ column: "*", table }]);
+    const userColumns = this.options_.columns ? this.options_.columns : schema.map((f) => f.column);
+    this.columns_ = resolveColumns(userColumns);
+    this.columnsByName_ = this.columns_.reduce(
+      (acc, col) => {
+        acc[col.column_name] = col;
+        return acc;
+      },
+      {}
+    );
     this.columns_.filter((c) => c.type !== "literal").forEach((column2) => {
       const item = schema.find((s) => s.column === column2.column_id);
       if (item) {
@@ -821,6 +818,9 @@ var Table = class extends Input {
     }
     query = query.where(...filter);
     Object.keys(this.filterModel_).forEach((columnName) => {
+      if (!this.columnsByName_) {
+        throw new Error("Columns not resolved yet. Please call prepare() first.");
+      }
       const col = this.columnsByName_[columnName];
       if (col.type !== "literal") {
         const useHaving = col?.type === "aggregate";
@@ -837,6 +837,9 @@ var Table = class extends Input {
     });
     if (this.sortModel_.length > 0) {
       this.sortModel_.forEach((sort) => {
+        if (!this.columnsByName_) {
+          throw new Error("Columns not resolved yet. Please call prepare() first.");
+        }
         const col = this.columnsByName_[sort.colId];
         if (col.type !== "literal") {
           query = query.orderby(sort.sort === "asc" ? asc(sort.colId) : desc(sort.colId));
@@ -856,7 +859,12 @@ var Table = class extends Input {
     return this;
   }
   updateGrid = throttle(async () => {
-    if (!this.grid_) return;
+    if (!this.grid_) {
+      return;
+    }
+    if (!this.columns_) {
+      throw new Error("Columns not resolved yet. Please call prepare() first.");
+    }
     const rowData = [];
     for (let i = 0; i < this.data_.numRows; i++) {
       const row = {};
@@ -945,12 +953,21 @@ var Table = class extends Input {
     };
   }
   getLiteralColumns() {
+    if (!this.columns_) {
+      throw new Error("Columns not resolved yet. Please call prepare() first.");
+    }
     return this.columns_.filter((c) => c.type === "literal");
   }
   getDatabaseColumns() {
+    if (!this.columns_) {
+      throw new Error("Columns not resolved yet. Please call prepare() first.");
+    }
     return this.columns_.filter((c) => c.type === "column" || c.type === "aggregate");
   }
   createColumnDef(column_name, type) {
+    if (!this.columnsByName_) {
+      throw new Error("Columns not resolved yet. Please call prepare() first.");
+    }
     const column2 = this.columnsByName_[column_name] || {};
     const align = column2.align || (type === "number" ? "right" : "left");
     const headerAlignment = column2.header_align;
@@ -1010,6 +1027,9 @@ var Table = class extends Input {
     const columns = this.grid_.getColumns();
     if (columns) {
       columns.forEach(async (column2) => {
+        if (!this.columnsByName_) {
+          throw new Error("Columns not resolved yet. Please call prepare() first.");
+        }
         const colId = column2.getColId();
         const filterInstance = await this.grid_.getColumnFilterInstance(colId);
         const col = this.columnsByName_[colId];

--- a/src/inspect_viz/_widgets/mosaic.js
+++ b/src/inspect_viz/_widgets/mosaic.js
@@ -445,7 +445,7 @@ var Slider = class extends Input {
       container.innerText = label;
       this.element.appendChild(container);
     }
-    let { value, width, min: min2, max: max2 } = options_;
+    let { value, width, min: min3, max: max3 } = options_;
     this.slider_ = document.createElement("div");
     this.slider_.classList.add("noUi-round");
     this.slider_.setAttribute("id", id);
@@ -485,10 +485,10 @@ var Slider = class extends Input {
       setupActivationListeners(this, this.slider_);
     }
     if (!options_.from) {
-      min2 = min2 ?? (Array.isArray(value) ? value[0] : value ?? 0);
-      max2 = max2 ?? (Array.isArray(value) ? value[1] : value ?? 0);
+      min3 = min3 ?? (Array.isArray(value) ? value[0] : value ?? 0);
+      max3 = max3 ?? (Array.isArray(value) ? value[1] : value ?? 0);
       const start = value ?? (options_.select === "interval" ? [0, 0] : 0);
-      this.updateSlider(min2, max2, start);
+      this.updateSlider(min3, max3, start);
     }
   }
   slider_;
@@ -529,27 +529,27 @@ var Slider = class extends Input {
   }
   queryResult(data) {
     const { min: dataMin, max: dataMax } = Array.from(data)[0];
-    const min2 = this.options_.min ?? dataMin;
-    const max2 = this.options_.max ?? dataMax;
+    const min3 = this.options_.min ?? dataMin;
+    const max3 = this.options_.max ?? dataMax;
     let start = this.sliderValue;
     if (!this.firstQuery_) {
       this.firstQuery_ = true;
       if (this.options_.value === void 0) {
-        start = this.options_.select === "interval" ? [min2, max2] : max2;
+        start = this.options_.select === "interval" ? [min3, max3] : max3;
       } else {
         start = this.options_.value;
       }
     }
-    this.updateSlider(min2, max2, start);
+    this.updateSlider(min3, max3, start);
     return this;
   }
-  updateSlider(min2, max2, start) {
-    const step = this.options_.step ?? (min2 >= 5 || max2 >= 5 ? 1 : void 0);
+  updateSlider(min3, max3, start) {
+    const step = this.options_.step ?? (min3 >= 5 || max3 >= 5 ? 1 : void 0);
     this.sliderApi_.updateOptions(
       {
         range: {
-          min: min2,
-          max: max2
+          min: min3,
+          max: max3
         },
         step,
         start
@@ -559,7 +559,7 @@ var Slider = class extends Input {
     return this;
   }
   clause(value) {
-    let { field, column: column2, min: min2, select = "point" } = this.options_;
+    let { field, column: column2, min: min3, select = "point" } = this.options_;
     field = field || column2;
     if (!field) {
       throw new Error(
@@ -567,7 +567,7 @@ var Slider = class extends Input {
       );
     }
     if (select === "interval" && value !== void 0) {
-      const domain = Array.isArray(value) ? value : [min2 ?? 0, value];
+      const domain = Array.isArray(value) ? value : [min3 ?? 0, value];
       return clauseInterval(field, domain, {
         source: this,
         bin: "ceil",
@@ -641,7 +641,41 @@ import {
   Query as Query3,
   sql,
   column,
-  avg
+  avg,
+  count,
+  sum,
+  argmax,
+  mad,
+  max as max2,
+  min as min2,
+  product,
+  geomean,
+  median,
+  mode,
+  variance,
+  stddev,
+  skewness,
+  kurtosis,
+  entropy,
+  varPop,
+  stddevPop,
+  first,
+  last,
+  stringAgg,
+  arrayAgg,
+  argmin,
+  quantile,
+  corr,
+  covarPop,
+  regrIntercept,
+  regrSlope,
+  regrCount,
+  regrR2,
+  regrSXX,
+  regrSYY,
+  regrSXY,
+  regrAvgX,
+  regrAvgY
 } from "https://cdn.jsdelivr.net/npm/@uwdata/mosaic-sql@0.16.2/+esm";
 import {
   createGrid,
@@ -658,7 +692,7 @@ var Table = class extends Input {
     ModuleRegistry.registerModules([AllCommunityModule]);
     this.id_ = generateId();
     this.columns_ = resolveColumns(this.options_.columns || ["*"]);
-    this.columnOptions_ = this.columns_.reduce(
+    this.columnsByName_ = this.columns_.reduce(
       (acc, col) => {
         acc[col.column_name] = col;
         return acc;
@@ -706,7 +740,7 @@ var Table = class extends Input {
   }
   id_;
   columns_;
-  columnOptions_;
+  columnsByName_;
   columnTypes_ = {};
   height_;
   gridContainer_;
@@ -721,8 +755,7 @@ var Table = class extends Input {
   };
   // contribute a selection clause back to the target selection
   clause(rows = []) {
-    const nonLiteralColumns = this.columns_.filter((col) => col.type !== "literal");
-    const fields = nonLiteralColumns.map((column2) => column2.column_id);
+    const fields = this.getDatabaseColumns().map((column2) => column2.column_id);
     const values = rows.map((row) => {
       return fields.map((f) => this.data_.columns[f][row]);
     });
@@ -732,17 +765,18 @@ var Table = class extends Input {
   // and do related setup
   async prepare() {
     const table = this.options_.from;
-    const nonLiteralCols = this.columns_.filter((col) => col.type !== "literal");
-    const fields = nonLiteralCols.map((column2) => ({ column: column2.column_id, table }));
+    const fields = this.getDatabaseColumns().map((column2) => ({
+      column: column2.column_id,
+      table
+    }));
     const schema = await queryFieldInfo(this.coordinator, fields);
-    schema.forEach(({ column: column2, type }) => {
-      const col = nonLiteralCols.find((c) => c.column_id === column2);
-      if (col) {
-        this.columnTypes_[col?.column_name] = type;
+    this.columns_.filter((c) => c.type !== "literal").forEach((column2) => {
+      const item = schema.find((s) => s.column === column2.column_id);
+      if (item) {
+        this.columnTypes_[column2.column_name] = item.type;
       }
     });
-    const literalCols = this.columns_.filter((col) => col.type === "literal");
-    literalCols.forEach((c) => {
+    this.getLiteralColumns().forEach((c) => {
       const colVal = c.column;
       if (Array.isArray(colVal)) {
         const firstVal = colVal[0];
@@ -769,13 +803,12 @@ var Table = class extends Input {
     const selectItems = {};
     const groupBy = [];
     let has_aggregate = false;
-    const nonLiteralCols = this.columns_.filter((col) => col.type !== "literal");
-    for (const column2 of nonLiteralCols) {
+    for (const column2 of this.getDatabaseColumns()) {
       if (column2.type === "aggregate") {
         const item = aggregateExpression(column2);
         selectItems[item[0]] = item[1];
         has_aggregate = true;
-      } else {
+      } else if (column2.type === "column") {
         selectItems[column2.column_id] = column2.column_id;
         groupBy.push(column2.column_id);
       }
@@ -788,21 +821,26 @@ var Table = class extends Input {
     }
     query = query.where(...filter);
     Object.keys(this.filterModel_).forEach((columnName) => {
-      const col = this.columns_.find((c) => c.column_name === columnName);
-      const useHaving = col?.type === "aggregate";
-      const filter2 = this.filterModel_[columnName];
-      const expression = filterExpression(columnName, filter2, query);
-      if (expression) {
-        if (useHaving) {
-          query.having(expression);
-        } else {
-          query = query.where(expression);
+      const col = this.columnsByName_[columnName];
+      if (col.type !== "literal") {
+        const useHaving = col?.type === "aggregate";
+        const filter2 = this.filterModel_[columnName];
+        const expression = filterExpression(columnName, filter2, query);
+        if (expression) {
+          if (useHaving) {
+            query.having(expression);
+          } else {
+            query = query.where(expression);
+          }
         }
       }
     });
     if (this.sortModel_.length > 0) {
       this.sortModel_.forEach((sort) => {
-        query = query.orderby(sort.sort === "asc" ? asc(sort.colId) : desc(sort.colId));
+        const col = this.columnsByName_[sort.colId];
+        if (col.type !== "literal") {
+          query = query.orderby(sort.sort === "asc" ? asc(sort.colId) : desc(sort.colId));
+        }
       });
     }
     return query;
@@ -854,12 +892,11 @@ var Table = class extends Input {
     });
     return {
       // always pass filter to allow server-side filtering
-      alwaysPassFilter: () => true,
       pagination: !!options.pagination,
       paginationAutoPageSize: options.pagination?.page_size === "auto" || options.pagination?.page_size === void 0,
       paginationPageSizeSelector: options.pagination?.page_size_selector,
       paginationPageSize: typeof options.pagination?.page_size === "number" ? options.pagination.page_size : void 0,
-      animateRows: true,
+      animateRows: false,
       headerHeight: headerHeightPixels,
       rowHeight: options.row_height,
       columnDefs: [],
@@ -901,32 +938,42 @@ var Table = class extends Input {
           this.currentRow_ = -1;
           this.options_.as.update(this.clause());
         }
+      },
+      onGridReady: () => {
+        this.patchGrid();
       }
     };
   }
-  createColumnDef(column2, type) {
-    const columnOptions = this.columnOptions_[column2] || {};
-    const align = columnOptions.align || (type === "number" ? "right" : "left");
-    const headerAlignment = columnOptions.header_align;
-    const formatter = formatterForType(type, columnOptions.format);
-    const sortable = this.options_.sorting !== false && columnOptions.sortable !== false;
-    const filterable = this.options_.filtering !== false && columnOptions.filterable !== false;
-    const resizable = columnOptions.resizable !== false;
-    const minWidth = columnOptions.min_width;
-    const maxWidth = columnOptions.max_width;
-    const autoHeight = columnOptions.auto_height;
-    const autoHeaderHeight = this.options_.header_height === "auto" && columnOptions.header_auto_height !== false;
-    const wrapText = columnOptions.wrap_text;
-    const wrapHeaderText = columnOptions.header_wrap_text;
-    const flex = columnOptions.flex;
+  getLiteralColumns() {
+    return this.columns_.filter((c) => c.type === "literal");
+  }
+  getDatabaseColumns() {
+    return this.columns_.filter((c) => c.type === "column" || c.type === "aggregate");
+  }
+  createColumnDef(column_name, type) {
+    const column2 = this.columnsByName_[column_name] || {};
+    const align = column2.align || (type === "number" ? "right" : "left");
+    const headerAlignment = column2.header_align;
+    const formatter = formatterForType(type, column2.format);
+    const sortable = this.options_.sorting !== false && column2.sortable !== false;
+    const filterable = this.options_.filtering !== false && column2.filterable !== false;
+    const resizable = column2.resizable !== false;
+    const minWidth = column2.min_width;
+    const maxWidth = column2.max_width;
+    const autoHeight = column2.auto_height;
+    const autoHeaderHeight = this.options_.header_height === "auto" && column2.header_auto_height !== false;
+    const wrapText = column2.wrap_text;
+    const wrapHeaderText = column2.header_wrap_text;
+    const flex = column2.flex;
+    const disableClientSort = (_valueA, _valueB) => {
+      return 0;
+    };
     const colDef = {
-      field: column2,
-      headerName: columnOptions.label || column2,
+      field: column_name,
+      headerName: column2.label || column_name,
       headerClass: headerClasses(headerAlignment),
       cellStyle: { textAlign: align },
-      comparator: (_valueA, _valueB) => {
-        return 0;
-      },
+      comparator: column2.type !== "literal" ? disableClientSort : void 0,
       filter: !filterable ? false : filterForColumnType(type),
       flex,
       sortable,
@@ -938,8 +985,8 @@ var Table = class extends Input {
       wrapText,
       wrapHeaderText,
       floatingFilter: this.options_.filtering === "row",
-      suppressMovable: true,
       // Disable column moving
+      suppressMovable: true,
       valueFormatter: (params) => {
         const value = params.value;
         if (formatter && value !== null && value !== void 0) {
@@ -948,13 +995,29 @@ var Table = class extends Input {
         return value;
       }
     };
-    const width = columnOptions.width;
+    const width = column2.width;
     if (width) {
       colDef.width = width;
     } else if (flex === void 0 || flex === null) {
       colDef.flex = 1;
     }
     return colDef;
+  }
+  patchGrid() {
+    if (!this.grid_) {
+      return;
+    }
+    const columns = this.grid_.getColumns();
+    if (columns) {
+      columns.forEach(async (column2) => {
+        const colId = column2.getColId();
+        const filterInstance = await this.grid_.getColumnFilterInstance(colId);
+        const col = this.columnsByName_[colId];
+        if (filterInstance && typeof filterInstance.doesFilterPass === "function" && col.type !== "literal") {
+          filterInstance.doesFilterPass = () => true;
+        }
+      });
+    }
   }
   // all mosaic inputs implement this, not exactly sure what it does
   activate() {
@@ -986,12 +1049,14 @@ var resolveColumns = (columns) => {
         };
       } else if (typeof col.column === "number") {
         return {
+          ...col,
           column_name: incrementedColumnName(),
           column: col.column,
           type: "literal"
         };
       } else if (typeof col.column === "boolean") {
         return {
+          ...col,
           column_name: incrementedColumnName(),
           column: col.column,
           type: "literal"
@@ -1001,6 +1066,7 @@ var resolveColumns = (columns) => {
           throw new Error("Empty array column is not supported");
         }
         return {
+          ...col,
           column_name: incrementedColumnName(),
           column: col.column,
           type: "literal"
@@ -1155,7 +1221,96 @@ var simpleExpression = (colId, type, filter, filterTo = void 0, textColumn = fal
   return void 0;
 };
 var aggregateExpression = (c) => {
-  return [c.column_name, avg(c.agg_expr_args[0])];
+  const aggExpr = c.agg_expr;
+  const firstArg = () => {
+    if (c.agg_expr_args.length > 0) {
+      return c.agg_expr_args[0];
+    }
+    throw new Error(`Aggregate expression ${aggExpr} requires at least one argument`);
+  };
+  const secondArg = () => {
+    if (c.agg_expr_args.length > 1) {
+      return c.agg_expr_args[1];
+    }
+    throw new Error(`Aggregate expression ${aggExpr} requires at least two arguments`);
+  };
+  const r = (val) => {
+    return [c.column_name, val];
+  };
+  switch (aggExpr) {
+    case "count":
+      return r(count(firstArg()));
+    case "sum":
+      return r(sum(firstArg()));
+    case "avg":
+      return r(avg(firstArg()));
+    case "argmax":
+      return r(argmax(firstArg(), secondArg()));
+    case "mad":
+      return r(mad(firstArg()));
+    case "max":
+      return r(max2(firstArg()));
+    case "min":
+      return r(min2(firstArg()));
+    case "product":
+      return r(product(firstArg()));
+    case "geomean":
+      return r(geomean(firstArg()));
+    case "median":
+      return r(median(firstArg()));
+    case "mode":
+      return r(mode(firstArg()));
+    case "variance":
+      return r(variance(firstArg()));
+    case "stddev":
+      return r(stddev(firstArg()));
+    case "skewness":
+      return r(skewness(firstArg()));
+    case "kurtosis":
+      return r(kurtosis(firstArg()));
+    case "entropy":
+      return r(entropy(firstArg()));
+    case "varPop":
+      return r(varPop(firstArg()));
+    case "stddevPop":
+      return r(stddevPop(firstArg()));
+    case "first":
+      return r(first(firstArg()));
+    case "last":
+      return r(last(firstArg()));
+    case "stringAgg":
+      return r(stringAgg(firstArg()));
+    case "arrayAgg":
+      return r(arrayAgg(firstArg()));
+    case "argmin":
+      return r(argmin(firstArg(), secondArg()));
+    case "quantile":
+      return r(quantile(firstArg(), secondArg()));
+    case "corr":
+      return r(corr(firstArg(), secondArg()));
+    case "covarPop":
+      return r(covarPop(firstArg(), secondArg()));
+    case "regrIntercept":
+      return r(regrIntercept(firstArg(), secondArg()));
+    case "regrSlope":
+      return r(regrSlope(firstArg(), secondArg()));
+    case "regrCount":
+      return r(regrCount(firstArg(), secondArg()));
+    case "regrR2":
+      return r(regrR2(firstArg(), secondArg()));
+    case "regrSXX":
+      return r(regrSXX(firstArg(), secondArg()));
+    case "regrSYY":
+      return r(regrSYY(firstArg(), secondArg()));
+    case "regrSXY":
+      return r(regrSXY(firstArg(), secondArg()));
+    case "regrAvgX":
+      return r(regrAvgX(firstArg(), secondArg()));
+    case "regrAvgY":
+      return r(regrAvgY(firstArg(), secondArg()));
+    default:
+      throw new Error(`Unsupported aggregate expression: ${aggExpr}`);
+  }
 };
 var isCombinedSimpleModel = (filter) => {
   return typeof filter === "object" && filter !== null && "operator" in filter && "conditions" in filter && (filter.operator === "AND" || filter.operator === "OR") && typeof filter.conditions === "object";

--- a/src/inspect_viz/_widgets/mosaic.js
+++ b/src/inspect_viz/_widgets/mosaic.js
@@ -640,7 +640,8 @@ import {
   suffix,
   Query as Query3,
   sql,
-  column
+  column,
+  avg
 } from "https://cdn.jsdelivr.net/npm/@uwdata/mosaic-sql@0.16.2/+esm";
 import {
   createGrid,
@@ -659,14 +660,13 @@ var Table = class extends Input {
     this.columns_ = resolveColumns(this.options_.columns || ["*"]);
     this.columnOptions_ = this.columns_.reduce(
       (acc, col) => {
-        acc[col.column] = col;
+        acc[col.column_name] = col;
         return acc;
       },
       {}
     );
     this.height_ = this.options_.height;
     this.currentRow_ = -1;
-    this.schema_ = [];
     this.element.classList.add("inspect-viz-table");
     if (typeof this.options_.width === "number") {
       this.element.style.width = `${this.options_.width}px`;
@@ -707,11 +707,11 @@ var Table = class extends Input {
   id_;
   columns_;
   columnOptions_;
+  columnTypes_ = {};
   height_;
   gridContainer_;
   grid_ = null;
   gridOptions_;
-  schema_;
   currentRow_;
   sortModel_ = [];
   filterModel_ = {};
@@ -721,7 +721,8 @@ var Table = class extends Input {
   };
   // contribute a selection clause back to the target selection
   clause(rows = []) {
-    const fields = this.schema_.map((s) => s.column);
+    const nonLiteralColumns = this.columns_.filter((col) => col.type !== "literal");
+    const fields = nonLiteralColumns.map((column2) => column2.column_id);
     const values = rows.map((row) => {
       return fields.map((f) => this.data_.columns[f][row]);
     });
@@ -731,26 +732,72 @@ var Table = class extends Input {
   // and do related setup
   async prepare() {
     const table = this.options_.from;
-    const fields = this.columns_.map((column2) => ({ column: column2.column, table }));
-    this.schema_ = await queryFieldInfo(this.coordinator, fields);
-    const columnDefs = this.schema_.map(
-      ({ column: column2, type }) => this.createColumnDef(column2, type)
-    );
+    const nonLiteralCols = this.columns_.filter((col) => col.type !== "literal");
+    const fields = nonLiteralCols.map((column2) => ({ column: column2.column_id, table }));
+    const schema = await queryFieldInfo(this.coordinator, fields);
+    schema.forEach(({ column: column2, type }) => {
+      const col = nonLiteralCols.find((c) => c.column_id === column2);
+      if (col) {
+        this.columnTypes_[col?.column_name] = type;
+      }
+    });
+    const literalCols = this.columns_.filter((col) => col.type === "literal");
+    literalCols.forEach((c) => {
+      const colVal = c.column;
+      if (Array.isArray(colVal)) {
+        const firstVal = colVal[0];
+        const typeStr = typeof firstVal === "boolean" ? "boolean" : typeof firstVal === "number" ? "number" : void 0;
+        if (typeStr) {
+          this.columnTypes_[c.column_name] = typeStr;
+        }
+      } else if (typeof colVal === "boolean") {
+        this.columnTypes_[c.column_name] = "boolean";
+      } else if (typeof colVal === "number") {
+        this.columnTypes_[c.column_name] = "number";
+      }
+    });
+    const columnDefs = this.columns_.map((column2) => {
+      const t = this.columnTypes_[column2.column_name];
+      return this.createColumnDef(column2.column_name, t);
+    });
     this.gridOptions_.columnDefs = columnDefs;
     this.grid_ = createGrid(this.gridContainer_, this.gridOptions_);
   }
   // mosaic calls this every time it needs to show data to find
   // out what query we want to run
   query(filter = []) {
+    const selectItems = {};
+    const groupBy = [];
+    let has_aggregate = false;
+    const nonLiteralCols = this.columns_.filter((col) => col.type !== "literal");
+    for (const column2 of nonLiteralCols) {
+      if (column2.type === "aggregate") {
+        const item = aggregateExpression(column2);
+        selectItems[item[0]] = item[1];
+        has_aggregate = true;
+      } else {
+        selectItems[column2.column_id] = column2.column_id;
+        groupBy.push(column2.column_id);
+      }
+    }
     let query = Query3.from(this.options_.from).select(
-      this.schema_.length ? this.schema_.map((s) => s.column) : "*"
+      Object.keys(selectItems).length ? selectItems : "*"
     );
+    if (has_aggregate && groupBy.length > 0) {
+      query.groupby(groupBy);
+    }
     query = query.where(...filter);
-    Object.keys(this.filterModel_).forEach((colId) => {
-      const filter2 = this.filterModel_[colId];
-      const expression = filterExpression(colId, filter2, query);
+    Object.keys(this.filterModel_).forEach((columnName) => {
+      const col = this.columns_.find((c) => c.column_name === columnName);
+      const useHaving = col?.type === "aggregate";
+      const filter2 = this.filterModel_[columnName];
+      const expression = filterExpression(columnName, filter2, query);
       if (expression) {
-        query = query.where(expression);
+        if (useHaving) {
+          query.having(expression);
+        } else {
+          query = query.where(expression);
+        }
       }
     });
     if (this.sortModel_.length > 0) {
@@ -775,8 +822,15 @@ var Table = class extends Input {
     const rowData = [];
     for (let i = 0; i < this.data_.numRows; i++) {
       const row = {};
-      this.schema_.forEach(({ column: column2 }) => {
-        row[column2] = this.data_.columns[column2][i];
+      this.columns_.forEach(({ column_name, column: column2 }) => {
+        if (Array.isArray(column2)) {
+          const index = i % column2.length;
+          row[column_name] = column2[index];
+        } else if (typeof column2 === "boolean" || typeof column2 === "number") {
+          row[column_name] = column2;
+        } else {
+          row[column_name] = this.data_.columns[column_name][i];
+        }
       });
       rowData.push(row);
     }
@@ -797,7 +851,6 @@ var Table = class extends Input {
       borderColor: this.options_.style?.border_color,
       borderRadius: this.options_.style?.border_radius,
       selectedRowBackgroundColor: this.options_.style?.selected_row_background_color
-      //borderWidth: this.options_.style?.border_width,
     });
     return {
       // always pass filter to allow server-side filtering
@@ -911,11 +964,61 @@ var Table = class extends Input {
   }
 };
 var resolveColumns = (columns) => {
+  let columnCount = 1;
+  const incrementedColumnName = () => {
+    return `col_${columnCount++}`;
+  };
   return columns.map((col) => {
     if (typeof col === "string") {
-      return { column: col };
+      return {
+        column_name: col,
+        column_id: col,
+        column: col,
+        type: "column"
+      };
     } else if (typeof col === "object" && col !== null) {
-      return col;
+      if (typeof col.column === "string") {
+        return {
+          ...col,
+          column_name: col.column,
+          column_id: col.column,
+          type: "column"
+        };
+      } else if (typeof col.column === "number") {
+        return {
+          column_name: incrementedColumnName(),
+          column: col.column,
+          type: "literal"
+        };
+      } else if (typeof col.column === "boolean") {
+        return {
+          column_name: incrementedColumnName(),
+          column: col.column,
+          type: "literal"
+        };
+      } else if (Array.isArray(col.column)) {
+        if (col.column.length === 0) {
+          throw new Error("Empty array column is not supported");
+        }
+        return {
+          column_name: incrementedColumnName(),
+          column: col.column,
+          type: "literal"
+        };
+      } else if (typeof col.column === "object") {
+        const agg = Object.keys(col.column)[0];
+        const targetColumn = col.column[agg];
+        return {
+          ...col,
+          column_name: `${agg}_${targetColumn}`,
+          column_id: targetColumn,
+          agg_expr: agg,
+          agg_expr_args: [targetColumn],
+          type: "aggregate"
+        };
+      } else {
+        throw new Error("Unsupported column type: " + typeof col.column);
+      }
     } else {
       throw new Error(`Invalid column definition: ${col}`);
     }
@@ -1050,6 +1153,9 @@ var simpleExpression = (colId, type, filter, filterTo = void 0, textColumn = fal
       console.warn(`Unsupported filter type: ${type}`);
   }
   return void 0;
+};
+var aggregateExpression = (c) => {
+  return [c.column_name, avg(c.agg_expr_args[0])];
 };
 var isCombinedSimpleModel = (filter) => {
   return typeof filter === "object" && filter !== null && "operator" in filter && "conditions" in filter && (filter.operator === "AND" || filter.operator === "OR") && typeof filter.conditions === "object";

--- a/src/inspect_viz/table/_table.py
+++ b/src/inspect_viz/table/_table.py
@@ -3,6 +3,8 @@ from typing import Literal, Sequence
 from pydantic import BaseModel, JsonValue
 
 from inspect_viz._util.marshall import dict_remove_none
+from inspect_viz.mark._channel import Channel
+from inspect_viz.transform._transform import Transform
 
 from .._core import Component, Data
 from .._core.selection import Selection
@@ -39,7 +41,7 @@ class Column(BaseModel):
             header cell.
     """
 
-    column: str
+    column: Channel
     label: str | None = None
     align: Literal["left", "right", "center", "justify"] | None = None
     format: str | None = None
@@ -58,7 +60,7 @@ class Column(BaseModel):
 
     def __init__(
         self,
-        column: str,
+        column: Channel,
         *,
         label: str | None = None,
         align: Literal["left", "right", "center", "justify"] | None = None,
@@ -97,7 +99,7 @@ class Column(BaseModel):
 
 
 def column(
-    column: str,
+    column: Channel,
     *,
     label: str | None = None,
     align: Literal["left", "right", "center", "justify"] | None = None,
@@ -314,10 +316,21 @@ def table(
 
 
 def validate_column(data: Data | None, column: str | Column) -> str | Column:
-    column_name = column.column if isinstance(column, Column) else column
-    if data is not None:
-        if column_name not in data.columns:
-            raise ValueError(f"Column '{column}' was not found in the data source.")
+    if data is None:
+        return column
+
+    column_name: str | None = None
+    if isinstance(column, Column):
+        if isinstance(column.column, str):
+            column_name = column.column
+        elif isinstance(column.column, Transform):
+            column_name = next(iter(column.column.values()))
+    else:
+        column_name = column
+
+    if column_name is not None and column_name not in data.columns:
+        raise ValueError(f"Column '{column_name}' was not found in the data source.")
+
     return column
 
 

--- a/src/inspect_viz/table/_table.py
+++ b/src/inspect_viz/table/_table.py
@@ -1,4 +1,4 @@
-from typing import Literal, Sequence
+from typing import Literal, Sequence, cast
 
 from pydantic import BaseModel, JsonValue
 
@@ -323,8 +323,8 @@ def validate_column(data: Data | None, column: str | Column) -> str | Column:
     if isinstance(column, Column):
         if isinstance(column.column, str):
             column_name = column.column
-        elif isinstance(column.column, Transform):
-            column_name = next(iter(column.column.values()))
+        elif isinstance(column.column, dict):
+            column_name = cast(str, next(iter(column.column.values())))
     else:
         column_name = column
 

--- a/src/inspect_viz/transform/_transform.py
+++ b/src/inspect_viz/transform/_transform.py
@@ -1,13 +1,60 @@
-from pydantic import JsonValue
+from typing import Any
+
+from pydantic import JsonValue, RootModel
 
 from inspect_viz._core.param import Param
 
 
-class Transform(dict[str, JsonValue]):
+class Transform(RootModel[dict[str, JsonValue]]):
     """Column transformation operation."""
 
-    def __init__(self, config: dict[str, JsonValue]) -> None:
-        super().__init__(config)
+    def __init__(self, config: dict[str, JsonValue] | None = None) -> None:
+        super().__init__(config or {})
+
+    def __getitem__(self, key: str) -> JsonValue:
+        return self.root[key]
+
+    def __setitem__(self, key: str, value: JsonValue) -> None:
+        self.root[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.root[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.root
+
+    def __iter__(self) -> Any:
+        return iter(self.root)
+
+    def __len__(self) -> int:
+        return len(self.root)
+
+    def keys(self) -> Any:
+        return self.root.keys()
+
+    def values(self) -> Any:
+        return self.root.values()
+
+    def items(self) -> Any:
+        return self.root.items()
+
+    def get(self, key: str, default: JsonValue = None) -> JsonValue:
+        return self.root.get(key, default)
+
+    def pop(self, key: str, default: JsonValue = None) -> JsonValue:
+        return self.root.pop(key, default)
+
+    def popitem(self) -> tuple[str, JsonValue]:
+        return self.root.popitem()
+
+    def clear(self) -> None:
+        self.root.clear()
+
+    def update(self, other: dict[str, JsonValue]) -> None:
+        self.root.update(other)
+
+    def setdefault(self, key: str, default: JsonValue = None) -> JsonValue:
+        return self.root.setdefault(key, default)
 
 
 TransformArg = str | float | bool | Param | list[str | float | bool | Param]

--- a/src/inspect_viz/transform/_transform.py
+++ b/src/inspect_viz/transform/_transform.py
@@ -1,60 +1,11 @@
-from typing import Any
+from typing import TypeAlias
 
-from pydantic import JsonValue, RootModel
+from pydantic import JsonValue
 
 from inspect_viz._core.param import Param
 
-
-class Transform(RootModel[dict[str, JsonValue]]):
-    """Column transformation operation."""
-
-    def __init__(self, config: dict[str, JsonValue] | None = None) -> None:
-        super().__init__(config or {})
-
-    def __getitem__(self, key: str) -> JsonValue:
-        return self.root[key]
-
-    def __setitem__(self, key: str, value: JsonValue) -> None:
-        self.root[key] = value
-
-    def __delitem__(self, key: str) -> None:
-        del self.root[key]
-
-    def __contains__(self, key: str) -> bool:
-        return key in self.root
-
-    def __iter__(self) -> Any:
-        return iter(self.root)
-
-    def __len__(self) -> int:
-        return len(self.root)
-
-    def keys(self) -> Any:
-        return self.root.keys()
-
-    def values(self) -> Any:
-        return self.root.values()
-
-    def items(self) -> Any:
-        return self.root.items()
-
-    def get(self, key: str, default: JsonValue = None) -> JsonValue:
-        return self.root.get(key, default)
-
-    def pop(self, key: str, default: JsonValue = None) -> JsonValue:
-        return self.root.pop(key, default)
-
-    def popitem(self) -> tuple[str, JsonValue]:
-        return self.root.popitem()
-
-    def clear(self) -> None:
-        self.root.clear()
-
-    def update(self, other: dict[str, JsonValue]) -> None:
-        self.root.update(other)
-
-    def setdefault(self, key: str, default: JsonValue = None) -> JsonValue:
-        return self.root.setdefault(key, default)
+Transform: TypeAlias = dict[str, JsonValue]
+"""Column transformation operation."""
 
 
 TransformArg = str | float | bool | Param | list[str | float | bool | Param]


### PR DESCRIPTION
Add support for table grouping and literals

You may now pass a `Channel` as the column, allowing it to specify a column name, an aggregate function (Transform), a single literal value (number or bool), or an array of literals (number or bool).

If aggregates are passed, other columns in the list will be included in a ‘group by’ clause.

If a single literal is passed, we’ll repeat that value for each row in the Data.

If an array of literal is passed, we’ll increment through the literals (row by row), looping through literals if needed.

Literal columns use client side filtering or sorting.

Example:

```
table(
    penguins,
    columns=[
        "species",
        "flipper_length",
        column(avg("bill_length")),
        column(avg("body_mass")),
        column([1,2,3,4,5,6,7], label=“literal-column)])
```