### PR TITLE
Improved support for date base regression lines

### DIFF
--- a/docs/examples/inspect/scores-timeline/index.qmd
+++ b/docs/examples/inspect/scores-timeline/index.qmd
@@ -16,9 +16,9 @@ from inspect_viz import Data, Selection
 from inspect_viz.input import checkbox_group, select
 from inspect_viz.layout import vconcat, vspace
 from inspect_viz.plot import plot, legend
-from inspect_viz.mark import dot, rule_x, text
+from inspect_viz.mark import dot, rule_x, text, regression_y
 from inspect_viz.table import table
-from inspect_viz.transform import ci_bounds
+from inspect_viz.transform import ci_bounds, epoch_ms
 
 # read data
 evals = Data.from_file("benchmarks.parquet") # <1>
@@ -29,6 +29,7 @@ ci_lower, ci_upper = ci_bounds( # <2>
     level=0.95,
     stderr="score_headline_stderr"
 ) # <2>
+
 
 vconcat(
     # select benchmark
@@ -43,7 +44,7 @@ vconcat(
         # benchmark score
         dot(
             evals,
-            x="model_release_date",
+            x=epoch_ms("model_release_date"),
             y="score_headline_value",
             r=3,
             fill="model_organization_name",
@@ -57,7 +58,7 @@ vconcat(
         # confidence interval
         rule_x( 
             evals,
-            x="model_release_date",
+            x=epoch_ms("model_release_date"),
             y="score_headline_value",
             y1=ci_lower,
             y2=ci_upper,
@@ -65,11 +66,16 @@ vconcat(
             stroke_opacity=0.4, # <4>
             marker="tick-x",
         ), 
+        regression_y(evals, 
+                x=epoch_ms("model_release_date"), 
+                y="score_headline_value", 
+                stroke="#AAAAAA"
+        ),
         # frontier annotation
         text(
             evals,
             text="model_display_name",  # <5>
-            x="model_release_date",
+            x=epoch_ms("model_release_date"),
             y="score_headline_value",
             line_anchor="middle",
             frame_anchor="right",
@@ -84,7 +90,9 @@ vconcat(
         y_label="Score",
         color_label="Organization",
         color_domain="fixed",
-        grid=True
+        x_tick_format="%b\n%Y",
+        grid=True,
+        
     )
 )
 ```

--- a/js/inputs/table.ts
+++ b/js/inputs/table.ts
@@ -822,11 +822,6 @@ const resolveRowSelection = (options: TableOptions): RowSelectionOptions<any, an
     }
 };
 
-interface FilterModel {
-    filter: string;
-    filterParams?: Record<string, unknown>;
-}
-
 const filterForColumnType = (type: string): FilterModel => {
     // Select the proper filter type based on the column type
     switch (type) {
@@ -844,7 +839,7 @@ const filterForColumnType = (type: string): FilterModel => {
                 filter: 'agTextColumnFilter',
                 filterParams: {
                     filterOptions: ['equals'],
-                    textMatcher: ({ filterText, value }) => {
+                    textMatcher: ({ filterText, value }: { filterText: string; value: any }) => {
                         // Convert boolean to string for comparison
                         const stringValue = String(value);
                         return stringValue === filterText;

--- a/js/plot/ticks.ts
+++ b/js/plot/ticks.ts
@@ -1,0 +1,48 @@
+import { Spec } from 'https://cdn.jsdelivr.net/npm/@uwdata/mosaic-spec@0.16.2/+esm';
+import * as d3TimeFormat from 'https://cdn.jsdelivr.net/npm/d3-time-format@4.1.0/+esm';
+import { visitPlot } from '../util/spec';
+
+export const applyTickFormatting = (spec: Spec) => {
+    // If the user specifies that they are formatting a timestamp
+    // then convert the value to a date format and apply the d3 time format
+
+    visitPlot(spec, (plot: Object) => {
+        // if we have a plot, then we need to set the plot defaults
+        if ('xTickFormat' in plot) {
+            const format = plot.xTickFormat;
+            if (typeof format === 'string') {
+                processTickFormat(plot, 'xTickFormat');
+                processTickFormat(plot, 'yTickFormat');
+            }
+        }
+    });
+};
+
+const processTickFormat = (obj: Record<string, any>, formatKey: string): void => {
+    // if we have a plot, then we need to set the plot defaults
+    if (formatKey in obj) {
+        const format = obj[formatKey];
+        if (typeof format === 'string') {
+            // If this is a d3 time format, then take over and process the values
+
+            // If the format is a date string, cooerce it to a date
+            if (isD3TimeFormat(format)) {
+                obj[formatKey] = (val: any) => {
+                    // Coerce the value to a date
+                    if (typeof val === 'number') {
+                        const d = new Date(val);
+                        return d3TimeFormat.timeFormat(format)(d);
+                    } else {
+                        return d3TimeFormat.timeFormat(format)(val);
+                    }
+                };
+            }
+        }
+    }
+};
+
+const isD3TimeFormat = (format: string): boolean => {
+    // We know this is a format string, so just look to see
+    // if there are date specific specifiers in the string
+    return /%[aAbBcdefHIjLmMpqQsSuUVwWxXyYzZ%]/.test(format);
+};

--- a/js/util/spec.ts
+++ b/js/util/spec.ts
@@ -1,0 +1,12 @@
+// Function that visits each plto in the spec and applies the provided function
+export function visitPlot(obj: Object, fn: (plot: Object) => void): void {
+    if (Array.isArray(obj)) {
+        obj.flatMap(item => visitPlot(item, fn));
+    } else if (typeof obj === 'object' && obj !== null) {
+        if ('plot' in obj) {
+            fn(obj);
+        } else {
+            Object.values(obj).flatMap(value => visitPlot(value, fn));
+        }
+    }
+}

--- a/js/widgets/mosaic.ts
+++ b/js/widgets/mosaic.ts
@@ -17,6 +17,7 @@ import { isNotebook } from '../util/platform';
 import { TableOptions } from '../inputs/table';
 import { replaceTooltipImpl as installPlotTooltips } from '../plot/tooltips';
 import { installTextCollisionHandler } from '../plot/text-collision';
+import { applyTickFormatting } from '../plot/ticks';
 
 interface MosaicProps {
     tables: Record<string, string>;
@@ -31,6 +32,9 @@ async function render({ model, el }: RenderProps<MosaicProps>) {
 
     // initialize context
     const ctx = await vizContext(plotDefaultsAst.plotDefaults);
+
+    // handle tick formatting
+    applyTickFormatting(spec);
 
     // insert/wait for tables to be ready
     const tables: Record<string, string> = model.get('tables') || {};

--- a/src/inspect_viz/transform/__init__.py
+++ b/src/inspect_viz/transform/__init__.py
@@ -19,7 +19,7 @@ from ._aggregate import (
     variance,
 )
 from ._ci import ci_bounds
-from ._column import bin, column, date_day, date_month, date_month_day
+from ._column import bin, column, date_day, date_month, date_month_day, epoch_ms
 from ._sql import sql
 from ._transform import Transform
 from ._window import (
@@ -46,6 +46,7 @@ __all__ = [
     "date_day",
     "date_month",
     "date_month_day",
+    "epoch_ms",
     "argmax",
     "argmin",
     "avg",

--- a/src/inspect_viz/transform/_column.py
+++ b/src/inspect_viz/transform/_column.py
@@ -3,6 +3,7 @@ from typing import Any, Literal, Sequence
 from pydantic import JsonValue
 
 from inspect_viz._util.marshall import dict_remove_none
+from inspect_viz.transform._sql import sql
 
 from .._core.param import Param
 from ._transform import Transform
@@ -115,3 +116,12 @@ def date_month(expr: str | Param) -> Transform:
     """
     config: dict[str, JsonValue] = {"dateMonth": expr}
     return Transform(config)
+
+
+def epoch_ms(expr: str | Param) -> Transform:
+    """Transform a Date value to epoch milliseconds.
+
+    Args:
+        expr: Expression or parameter.
+    """
+    return sql(f"epoch_ms({expr})")


### PR DESCRIPTION
Improved support for date base regression lines
- Expose epoch_ms transform for getting timestamps from dates
- Add support for x_ticks_format, y_ticks_format specifying a time format string for epoch columns
- update example to illustrate this
- update scores_timeline to have a regression option