### PR TITLE
Update prepare arguments in docs

### DIFF
--- a/docs/view-sample-heatmap.qmd
+++ b/docs/view-sample-heatmap.qmd
@@ -39,8 +39,8 @@ from inspect_ai.analysis import samples_df, log_viewer, model_info, prepare, Eva
 
 df = samples_df("logs", columns=SampleSummary + EvalModel)
 df = prepare(df, 
-    model_info(), 
-    log_viewer("sample", {"logs": "https://samples.meridianlabs.ai/"}),
+    [model_info(), 
+    log_viewer("sample", {"logs": "https://samples.meridianlabs.ai/"})]
   )
 df.to_parquet("writing_bench_samples.parquet")
 ```
@@ -52,9 +52,9 @@ from inspect_ai.analysis import samples_df, log_viewer, model_info, score_to_flo
 
 df = samples_df("logs", columns=SampleSummary + EvalModel)
 df = prepare(df, 
-    model_info(), 
+    [model_info(), 
     log_viewer("sample", {"logs": "https://samples.meridianlabs.ai/"}),
-    score_to_float("score_includes")
+    score_to_float("score_includes")]
   )
 ```
 


### PR DESCRIPTION
Not sure what the preferred formatting in .qmd files is, but [prepare](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/analysis/_prepare/prepare.py#L11) only takes 2 args and the 2nd arg needs to be a list if there are additional values.