### PR TITLE
Position labels using pixel offset and angle quadrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 dist
 .DS_Store
 uv.lock
+*.code-workspace
 
 # Python
 __pycache__

--- a/docs/examples/inspect/scores-radar/index.qmd
+++ b/docs/examples/inspect/scores-radar/index.qmd
@@ -16,6 +16,7 @@ from inspect_viz._core.selection import Selection
 from inspect_viz.mark import circle, line, text
 from inspect_viz.plot import plot
 from inspect_viz.plot._legend import legend
+from inspect_viz.view.beta import LabelStyles
 from inspect_viz.view.beta._scores_radar import (
     axes_coordinates,
     grid_circles_coordinates,
@@ -35,7 +36,7 @@ channels = {  # <2>
 metrics = data.column_unique("metric")
 axes = axes_coordinates(num_axes=len(metrics))  # <3>
 grid_circles = grid_circles_coordinates()  # <3>
-labels = labels_coordinates(metrics=metrics, new_line=True)  # <3>
+labels = labels_coordinates(metrics=metrics)  # <3>
 
 # enable interactive highlighting of a chosen model
 model_selection = Selection.single()  # <4>
@@ -88,6 +89,7 @@ elements = [
             y=label["y"],  # <9>
             text=label["metric"],  # <9>
             frame_anchor=label["frame_anchor"],  # <9>
+            styles=LabelStyles(line_width=3),  # <9>
         )  # <9>
         for label in labels  # <9>
     ],  # <9>

--- a/docs/examples/inspect/scores-radar/index.qmd
+++ b/docs/examples/inspect/scores-radar/index.qmd
@@ -89,7 +89,7 @@ elements = [
             y=label["y"],  # <9>
             text=label["metric"],  # <9>
             frame_anchor=label["frame_anchor"],  # <9>
-            styles=LabelStyles(line_width=3),  # <9>
+            styles=LabelStyles(line_width=8),  # <9>
         )  # <9>
         for label in labels  # <9>
     ],  # <9>
@@ -97,7 +97,7 @@ elements = [
 
 plot(
     elements,
-    margin=48,
+    margin=60,
     x_axis=False,  # <10>
     y_axis=False,  # <10>
     width=400,

--- a/docs/examples/inspect/scores-radar/index.qmd
+++ b/docs/examples/inspect/scores-radar/index.qmd
@@ -35,7 +35,7 @@ channels = {  # <2>
 metrics = data.column_unique("metric")
 axes = axes_coordinates(num_axes=len(metrics))  # <3>
 grid_circles = grid_circles_coordinates()  # <3>
-labels = labels_coordinates(metrics=metrics)  # <3>
+labels = labels_coordinates(metrics=metrics, new_line=True)  # <3>
 
 # enable interactive highlighting of a chosen model
 model_selection = Selection.single()  # <4>
@@ -82,20 +82,24 @@ elements = [
         tip=False,  # <8>
     ),
     # axis labels
-    text(  # <9>
-        x=labels["x"],  # <9>
-        y=labels["y"],  # <9>
-        text=labels["metric"],  # <9>
-    ),  # <9>
+    *[  # <9>
+        text(  # <9>
+            x=label["x"],  # <9>
+            y=label["y"],  # <9>
+            text=label["metric"],  # <9>
+            frame_anchor=label["frame_anchor"],  # <9>
+        )  # <9>
+        for label in labels  # <9>
+    ],  # <9>
 ]
 
 plot(
     elements,
-    margin=60,
+    margin=48,
     x_axis=False,  # <10>
     y_axis=False,  # <10>
-    width=500,
-    height=500,
+    width=400,
+    height=400,
     legend=legend("color", target=model_selection),  # <11>
 )
 ```

--- a/docs/view-scores-radar.qmd
+++ b/docs/view-scores-radar.qmd
@@ -16,10 +16,13 @@ The `scores_radar()`function renders a radar chart for comparing eval scores acr
 
 ```{python}
 from inspect_viz import Data
-from inspect_viz.view.beta import scores_radar
+from inspect_viz.view.beta import scores_radar, LabelStyles
 
 evals = Data.from_file("writing_bench_radar.parquet")
-scores_radar(evals, new_line=True)
+scores_radar(
+  evals,
+  label_styles=LabelStyles(line_width=3)  # wrap label text
+)
 ```
 
 ## Data Preparation

--- a/docs/view-scores-radar.qmd
+++ b/docs/view-scores-radar.qmd
@@ -19,10 +19,7 @@ from inspect_viz import Data
 from inspect_viz.view.beta import scores_radar, LabelStyles
 
 evals = Data.from_file("writing_bench_radar.parquet")
-scores_radar(
-  evals,
-  label_styles=LabelStyles(line_width=3)  # wrap label text
-)
+scores_radar(evals)
 ```
 
 ## Data Preparation

--- a/docs/view-scores-radar.qmd
+++ b/docs/view-scores-radar.qmd
@@ -19,7 +19,7 @@ from inspect_viz import Data
 from inspect_viz.view.beta import scores_radar
 
 evals = Data.from_file("writing_bench_radar.parquet")
-scores_radar(evals)
+scores_radar(evals, new_line=True)
 ```
 
 ## Data Preparation

--- a/src/inspect_viz/view/beta/__init__.py
+++ b/src/inspect_viz/view/beta/__init__.py
@@ -6,7 +6,7 @@ from ._scores_by_limit import scores_by_limit, scores_by_limit_df
 from ._scores_by_model import scores_by_model
 from ._scores_by_task import scores_by_task
 from ._scores_heatmap import scores_heatmap
-from ._scores_radar import scores_radar, scores_radar_df
+from ._scores_radar import LabelStyles, scores_radar, scores_radar_df
 from ._scores_timeline import scores_timeline
 
 __all__ = [
@@ -24,4 +24,5 @@ __all__ = [
     "heatmap",
     "scores_radar",
     "scores_radar_df",
+    "LabelStyles",
 ]

--- a/src/inspect_viz/view/beta/_scores_radar.py
+++ b/src/inspect_viz/view/beta/_scores_radar.py
@@ -124,14 +124,53 @@ def compute_angles(num_axes: int, endpoint: bool = True) -> NDArray[np.floating[
     return np.linspace(0, 2 * np.pi, num_axes, endpoint=endpoint)
 
 
-def labels_coordinates(metrics: list[str]) -> dict[str, list[str] | list[float]]:
-    """Computes coordinates for labels to be used in a radar chart."""
+def labels_coordinates(
+    metrics: list[str], new_line: bool = False, width: float = 400, margin: float = 0
+) -> list[dict[str, Any]]:
+    """Computes coordinates for labels to be used in a radar chart.
+
+    Args:
+        metrics: List of metric names for label text.
+        new_line: Whether to replace whitespace with new lines in the metric name.
+        width: Chart width in pixels, used to calculate radius.
+        margin: Margin in pixels (defaults to 0) to substract from width.
+
+    Returns:
+        List of dictionaries, each containing text mark arguments for one label.
+    """
     angles = compute_angles(len(metrics), endpoint=False)
-    return {
-        "metric": metrics,
-        "x": (1.24 * np.cos(angles)).tolist(),
-        "y": (1.24 * np.sin(angles)).tolist(),
-    }
+
+    # 15px offset regardless of chart size
+    chart_radius_px = (width - 2 * margin) / 2
+    label_offset_px = 15
+
+    # convert to coordinate space: boundary circle is at radius 1.0
+    label_radius = 1.0 + (label_offset_px / chart_radius_px)
+
+    labels = []
+    for metric, angle in zip(metrics, angles, strict=True):
+        angle_deg = np.degrees(angle) % 360
+
+        # determine frame_anchor based on quadrant
+        if 315 <= angle_deg or angle_deg < 45:  # right side
+            frame_anchor = "left"
+        elif 45 <= angle_deg < 135:  # top
+            frame_anchor = "bottom"
+        elif 135 <= angle_deg < 225:  # left side
+            frame_anchor = "right"
+        else:  # 225 <= angle_deg < 315, bottom
+            frame_anchor = "top"
+
+        labels.append(
+            {
+                "metric": [metric.replace(" ", "\n") if new_line else metric],
+                "x": [float(label_radius * np.cos(angle))],
+                "y": [float(label_radius * np.sin(angle))],
+                "frame_anchor": frame_anchor,
+            }
+        )
+
+    return labels
 
 
 def axes_coordinates(num_axes: int) -> dict[str, list[float]]:
@@ -160,7 +199,8 @@ def scores_radar(
     data: Data,
     model: str = "model_display_name",
     title: str | Title | None = None,
-    width: float | None = 400,
+    width: float = 400,
+    new_line: bool = False,
     legend: Legend | NotGiven | None = NOT_GIVEN,
     **attributes: Unpack[PlotAttributes],
 ) -> Component:
@@ -171,10 +211,12 @@ def scores_radar(
         data: A `Data` object prepared using the `scores_radar_df` function.
         model: Name of field holding the model (defaults to "model_display_name").
         title: Title for plot (`str` or mark created with the `title()` function)
-        width: The outer width of the plot in pixels, including margins. Defaults to 500.
+        width: The outer width of the plot in pixels, including margins. Defaults to 400.
                Height is automatically set to match width to maintain square aspect ratio.
+        new_line: Whether to replace whitespace with new lines in label text. Defaults to False.
         legend: Options for the legend. Pass None to disable the legend.
         **attributes: Additional `PlotAttributes`.
+                      Use `margin` to set custom margin (defaults to max(30, width * 0.12)).
     """
     if "model_display_name" not in data.columns:
         model = "model"
@@ -184,10 +226,16 @@ def scores_radar(
     if missing_columns:
         raise ValueError(f"Required columns not found in data: {missing_columns}")
 
+    # use margin from attributes or calculate default
+    margin_attr = attributes.get("margin")
+    plot_margin = int(margin_attr) if margin_attr else max(30, int(width * 0.12))
+
     metrics = data.column_unique("metric")
     axes = axes_coordinates(num_axes=len(metrics))
     grid_circles = grid_circles_coordinates()
-    labels = labels_coordinates(metrics=metrics)
+    labels = labels_coordinates(
+        metrics=metrics, new_line=new_line, width=width, margin=plot_margin
+    )
 
     model_selection = Selection.single()
 
@@ -264,11 +312,15 @@ def scores_radar(
             tip=False,
         ),
         # axis labels
-        text(
-            x=labels["x"],
-            y=labels["y"],
-            text=labels["metric"],
-        ),
+        *[
+            text(
+                x=label["x"],
+                y=label["y"],
+                text=label["metric"],
+                frame_anchor=label["frame_anchor"],
+            )
+            for label in labels
+        ],
     ]
 
     plot_legend = (
@@ -279,7 +331,7 @@ def scores_radar(
 
     # resolve default attributes
     defaults: PlotAttributes = {
-        "margin": max(30, int(width * 0.12)) if width else 36,
+        "margin": plot_margin,
         "x_axis": False,
         "y_axis": False,
     }

--- a/src/inspect_viz/view/beta/_scores_radar.py
+++ b/src/inspect_viz/view/beta/_scores_radar.py
@@ -1,10 +1,11 @@
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
 from numpy.typing import NDArray
-from typing_extensions import Unpack
+from typing_extensions import TypedDict, Unpack
 
+from inspect_viz._core import Param
 from inspect_viz._core.component import Component
 from inspect_viz._core.data import Data
 from inspect_viz._core.selection import Selection
@@ -12,10 +13,20 @@ from inspect_viz._util.channels import resolve_log_viewer_channel
 from inspect_viz._util.notgiven import NOT_GIVEN, NotGiven
 from inspect_viz.mark import circle, line, text
 from inspect_viz.mark._title import Title
+from inspect_viz.mark._types import TextOverflow, TextStyles
 from inspect_viz.plot import plot
 from inspect_viz.plot._attributes import PlotAttributes
 from inspect_viz.plot._legend import Legend
 from inspect_viz.plot._legend import legend as create_legend
+
+
+class LabelStyles(TypedDict, total=False):
+    """Label styling options. It's a subset of `TextStyles`."""
+
+    line_width: float | Param
+    """The line width in ems (e.g., 10 for about 20 characters); defaults to infinity, disabling wrapping and clipping. If **text_overflow** is null, lines will be wrapped at the specified length. If a line is split at a soft hyphen (\xad), a hyphen (-) will be displayed at the end of the line. If **text_overflow** is not null, lines will be clipped according to the given strategy."""
+    text_overflow: TextOverflow | Param
+    """Text overflow behavior."""
 
 
 def scores_radar_df(
@@ -125,13 +136,12 @@ def compute_angles(num_axes: int, endpoint: bool = True) -> NDArray[np.floating[
 
 
 def labels_coordinates(
-    metrics: list[str], new_line: bool = False, width: float = 400, margin: float = 0
+    metrics: list[str], width: float = 400, margin: float = 0
 ) -> list[dict[str, Any]]:
     """Computes coordinates for labels to be used in a radar chart.
 
     Args:
         metrics: List of metric names for label text.
-        new_line: Whether to replace whitespace with new lines in the metric name.
         width: Chart width in pixels, used to calculate radius.
         margin: Margin in pixels (defaults to 0) to substract from width.
 
@@ -163,7 +173,7 @@ def labels_coordinates(
 
         labels.append(
             {
-                "metric": [metric.replace(" ", "\n") if new_line else metric],
+                "metric": [metric],
                 "x": [float(label_radius * np.cos(angle))],
                 "y": [float(label_radius * np.sin(angle))],
                 "frame_anchor": frame_anchor,
@@ -200,8 +210,8 @@ def scores_radar(
     model: str = "model_display_name",
     title: str | Title | None = None,
     width: float = 400,
-    new_line: bool = False,
     legend: Legend | NotGiven | None = NOT_GIVEN,
+    label_styles: LabelStyles | None = None,
     **attributes: Unpack[PlotAttributes],
 ) -> Component:
     """
@@ -213,8 +223,8 @@ def scores_radar(
         title: Title for plot (`str` or mark created with the `title()` function)
         width: The outer width of the plot in pixels, including margins. Defaults to 400.
                Height is automatically set to match width to maintain square aspect ratio.
-        new_line: Whether to replace whitespace with new lines in label text. Defaults to False.
         legend: Options for the legend. Pass None to disable the legend.
+        label_styles: Label styling options. It accepts `line_width` and `text_overflow`.
         **attributes: Additional `PlotAttributes`.
                       Use `margin` to set custom margin (defaults to max(30, width * 0.12)).
     """
@@ -233,9 +243,7 @@ def scores_radar(
     metrics = data.column_unique("metric")
     axes = axes_coordinates(num_axes=len(metrics))
     grid_circles = grid_circles_coordinates()
-    labels = labels_coordinates(
-        metrics=metrics, new_line=new_line, width=width, margin=plot_margin
-    )
+    labels = labels_coordinates(metrics=metrics, width=width, margin=plot_margin)
 
     model_selection = Selection.single()
 
@@ -318,6 +326,7 @@ def scores_radar(
                 y=label["y"],
                 text=label["metric"],
                 frame_anchor=label["frame_anchor"],
+                styles=cast(TextStyles, label_styles) if label_styles else None,
             )
             for label in labels
         ],

--- a/src/inspect_viz/view/beta/_scores_radar.py
+++ b/src/inspect_viz/view/beta/_scores_radar.py
@@ -238,7 +238,13 @@ def scores_radar(
 
     # use margin from attributes or calculate default
     margin_attr = attributes.get("margin")
-    plot_margin = int(margin_attr) if margin_attr else max(30, int(width * 0.12))
+    plot_margin = int(margin_attr) if margin_attr else max(60, int(width * 0.12))
+
+    # wrap label text if any metric name is longer than 10 characters
+    if not label_styles and any(
+        len(metric) > 10 for metric in data.column_unique("metric")
+    ):
+        label_styles = LabelStyles(line_width=8)
 
     metrics = data.column_unique("metric")
     axes = axes_coordinates(num_axes=len(metrics))


### PR DESCRIPTION
Radar chart labels used a positioning that was proportional to the chart size, placing the labels too far for large charts and too close for small charts. In this PR I update to use a fixed 15px offset independent of chart size and choose the frame anchor based on the angle quadrant they're in.