### PR TITLE
docs: fix typo in model_info & args for prepare

### DIFF
--- a/docs/_data_preparation.md
+++ b/docs/_data_preparation.md
@@ -9,10 +9,10 @@ Above we read the data for the plot from a parquet file. This file was in turn c
 from inspect_ai.analysis import evals_df, log_viewer, model_info, prepare
 
 df = evals_df("logs")
-df = prepare(df, 
+df = prepare(df, [
     model_info(),
-    log_viewer("eval", {"logs": "https://samples.meridianlabs.ai/"}),
-)
+    log_viewer("eval", {"logs": "https://samples.meridianlabs.ai/"})
+])
 df.to_parquet("{{< meta datafile>}}")
 ```
 

--- a/docs/_data_preparation.md
+++ b/docs/_data_preparation.md
@@ -6,7 +6,7 @@ Above we read the data for the plot from a parquet file. This file was in turn c
 2. Using the [`prepare()`](https://inspect.aisi.org.uk/reference/inspect_ai.analysis.html#prepare) function to add [`model_info()`](https://inspect.aisi.org.uk/reference/inspect_ai.analysis.html#model_info) and [`log_viewer()`](https://inspect.aisi.org.uk/reference/inspect_ai.analysis.html#model_info) columns to the data frame.
 
 ```python
-from inspect_ai.analysis import evals_df, log_viewer, model_into, prepare
+from inspect_ai.analysis import evals_df, log_viewer, model_info, prepare
 
 df = evals_df("logs")
 df = prepare(df, 

--- a/docs/_data_preparation_scores_by_limit.md
+++ b/docs/_data_preparation_scores_by_limit.md
@@ -26,10 +26,10 @@ df = scores_by_limit_df(                          # <3>
     score="score_swe_bench_scorer",        # <3>
 )
 
-df = prepare(df,                                                     #<4>
+df = prepare(df, [                                                   #<4>
   model_info(),                                                      #<4>
   log_viewer("eval", { "logs": "https://samples.meridianlabs.ai/" }) #<4>
-)                                                                  #<4>
+])                                                                  #<4>
 
 df.to_parquet("{{< meta datafile>}}")
 ```

--- a/docs/view-sample-heatmap.qmd
+++ b/docs/view-sample-heatmap.qmd
@@ -38,10 +38,10 @@ Above we read the data for the plot from a parquet file. This file was in turn c
 from inspect_ai.analysis import samples_df, log_viewer, model_info, prepare, EvalModel, SampleSummary
 
 df = samples_df("logs", columns=SampleSummary + EvalModel)
-df = prepare(df, 
-    [model_info(), 
-    log_viewer("sample", {"logs": "https://samples.meridianlabs.ai/"})]
-  )
+df = prepare(df, [
+    model_info(), 
+    log_viewer("sample", {"logs": "https://samples.meridianlabs.ai/"})
+  ])
 df.to_parquet("writing_bench_samples.parquet")
 ```
 
@@ -51,11 +51,11 @@ If your samples are using non-numeric values (for example 'C' and 'I' to represe
 from inspect_ai.analysis import samples_df, log_viewer, model_info, score_to_float, prepare, EvalModel, SampleSummary
 
 df = samples_df("logs", columns=SampleSummary + EvalModel)
-df = prepare(df, 
-    [model_info(), 
+df = prepare(df, [
+    model_info(), 
     log_viewer("sample", {"logs": "https://samples.meridianlabs.ai/"}),
-    score_to_float("score_includes")]
-  )
+    score_to_float("score_includes")
+  ])
 ```
 
 {{< include _data_preparation_optional.md >}}

--- a/docs/view-scores-timeline.qmd
+++ b/docs/view-scores-timeline.qmd
@@ -33,7 +33,7 @@ Above we read the data for the plot from a parquet file. This file was in turn c
 
 ```python
 from inspect_ai.analysis import (
-    evals_df, frontier, log_viewer, model_into, prepare
+    evals_df, frontier, log_viewer, model_info, prepare
 )
 
 df = evals_df("logs")

--- a/docs/view-scores-timeline.qmd
+++ b/docs/view-scores-timeline.qmd
@@ -37,11 +37,11 @@ from inspect_ai.analysis import (
 )
 
 df = evals_df("logs")
-df = prepare(df, 
+df = prepare(df, [
     model_info(),
     frontier(),
-    log_viewer("eval", {"logs": "https://samples.meridianlabs.ai/"}),
-)
+    log_viewer("eval", {"logs": "https://samples.meridianlabs.ai/"})
+])
 df.to_parquet("{{< meta datafile>}}")
 ```
 


### PR DESCRIPTION
`model_into` -> `model_info` and additional fixes (plus consistent formatting) for the issue in #19.