### PR TITLE
chore: versioning to patch-pre-major (stop no-op releases) + restore approvers

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,4 +10,6 @@ jobs:
       contents: write
       pull-requests: write
     uses: meridianlabs-ai/actions/.github/workflows/release-please-python.yml@v1
+    with:
+      approvers: "dragonstyle jjallaire epatey"
     secrets: inherit

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,7 +1,5 @@
 {
   "release-type": "python",
-  "include-v-in-tag": false,
-  "versioning": "always-bump-patch",
   "packages": {
     ".": {
       "changelog-sections": [
@@ -56,7 +54,9 @@
       ],
       "release-notes-config": {
         "grouping": true
-      }
+      },
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
Follow-up to the pilot, fixing two things surfaced by the `0.4.1` release.

## 1. Stop no-op releases (`always-bump-patch` → `patch-pre-major`)
`0.4.1` was cut from a `chore` + a docs commit with **zero `src/` changes** — because `always-bump-patch` releases on *every* commit. Switching to **`bump-patch-for-minor-pre-major`** (+ `bump-minor-pre-major`, per-package) gives the intended behavior:
- `feat:` → **patch**, `fix:` → patch
- `chore:` / `docs:` / CI → **no release** (no more empty bumps)
- breaking (`feat!:`) → minor; explicit minors via `Release-As:`

Also drops the ignored top-level `include-v-in-tag`.

## 2. Restore the `approvers` input
The `approvers: "dragonstyle jjallaire epatey"` input was lost when PR #27's branch got re-created after merge. Restoring it so the Slack approval ping @-mentions the approvers.

## Verify after merge
- A **docs/chore-only** merge should cut **no** release PR (confirms the fix).
- A **fix:** merge should cut a **patch** (0.4.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)