### PR TITLE
chore: keep bare tags on inspect_viz (per-package include-v-in-tag)

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -56,7 +56,8 @@
         "grouping": true
       },
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "include-v-in-tag": false
     }
   }
 }


### PR DESCRIPTION
viz historically used **bare** tags (`0.4.0`), but the pilot flipped it to `v0.4.1` — because top-level `include-v-in-tag` is ignored in manifest mode. This places `include-v-in-tag: false` **per-package** so viz returns to bare from `0.4.2`.

- `v0.4.1` stays as a one-off (retagging a published release isn't worth the risk; PyPI version is unaffected).
- Also **verifies per-package placement works** before the other bare repos (`swe`, `scout`, `petri_dish`, `petri_bloom`) migrate — viz's next release should be `0.4.2` (bare), not `v0.4.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)