### PR TITLE
chore: post approval ping from publish.yaml (deep-link to paused run)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,19 @@ on:
                 type: string
 
 jobs:
+    # Post the "awaiting approval" Slack ping. Runs un-gated in this same run,
+    # so it deep-links to the run whose publish job is paused on the pypi env.
+    notify-approval:
+        if: ${{ github.event_name == 'release' }}
+        runs-on: ubuntu-latest
+        steps:
+            - uses: meridianlabs-ai/actions/slack-approval-ping@v1
+              with:
+                  webhook: ${{ secrets.SLACK_APPROVALS_WEBHOOK_URL }}
+                  approvers: "dragonstyle jjallaire epatey"
+                  message: ":rocket: *${{ github.repository }}* ${{ github.event.release.tag_name }} — PyPI publish is *awaiting approval*."
+                  run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
     publish:
         runs-on: ubuntu-latest
         permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,5 +11,8 @@ jobs:
       pull-requests: write
     uses: meridianlabs-ai/actions/.github/workflows/release-please-python.yml@v1
     with:
-      approvers: "dragonstyle jjallaire epatey"
+      # Publishing (and the approval gate) is in publish.yaml, a separate
+      # `on: release` run — so the approval ping is posted from there (where it
+      # can deep-link to the paused run), not from this workflow.
+      approval-ping: false
     secrets: inherit


### PR DESCRIPTION
Follow-up to actions PR #60. viz publishes via `publish.yaml` (`on: release`) — a separate run from release-please — so the reusable workflow's ping can't deep-link to the paused publish run. This:
- sets `approval-ping: false` on the reusable release-please call, and
- adds a non-gated `notify-approval` job in `publish.yaml` that posts via `slack-approval-ping@v1`, deep-linking to `github.run_id` (the run whose publish job pauses on the `pypi` environment).

This is the viz-style pattern the remaining manual-migration repos (swe, petri_dish, petri_bloom) will use from the start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)