### PR TITLE
chore: regenerate release-please config (drop invalid key, hide docs/chore/refactor)

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -21,15 +21,18 @@
         },
         {
           "type": "refactor",
-          "section": "Code Refactoring"
+          "section": "Code Refactoring",
+          "hidden": true
         },
         {
           "type": "docs",
-          "section": "Documentation"
+          "section": "Documentation",
+          "hidden": true
         },
         {
           "type": "chore",
-          "section": "Miscellaneous"
+          "section": "Miscellaneous",
+          "hidden": true
         },
         {
           "type": "build",
@@ -52,9 +55,6 @@
           "hidden": true
         }
       ],
-      "release-notes-config": {
-        "grouping": true
-      },
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "include-v-in-tag": false


### PR DESCRIPTION
Regenerates the committed release-please config from the fixed generator.

Changes:
- Removes the invalid \`release-notes-config: { grouping: true }\` key.
- Hides the \`docs\`, \`chore\`, and \`refactor\` changelog sections so release notes surface \`feat\`/\`fix\`/\`perf\`/\`revert\` only.

Mirrors meridianlabs-ai/actions#64 and #65. No change to release-type (python), tag-format (bare), or versioning (patch-pre-major).

🤖 Generated with [Claude Code](https://claude.com/claude-code)