### PR TITLE
ci: drop redundant target-branch dispatch input (single-control hotfix)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,11 +4,6 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-    inputs:
-      target-branch:
-        description: "Maintenance branch to release from (e.g. hotfix/1.4.x). Leave as main for a normal release."
-        type: string
-        default: main
 
 jobs:
   release-please:
@@ -21,5 +16,4 @@ jobs:
       # `on: release` run — so the approval ping is posted from there (where it
       # can deep-link to the paused run), not from this workflow.
       approval-ping: false
-      target-branch: ${{ inputs.target-branch }}
     secrets: inherit


### PR DESCRIPTION
The reusable workflow now derives `target-branch` from the dispatched branch (`github.ref_name`), so this input is redundant and its `default: main` would override it. Removing it makes the **"Use workflow from" branch selector the sole control** (mirrors meridianlabs-ai/actions#66). Normal push-to-main releases unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)