### PR TITLE
docs: add Changelog title + fix 0.4.1 section placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,4 @@
-## 0.4.0 (April 19, 2026)
-
-- Quarto: Write plot data to content-addressed `site_data/immutable/*.arrow` assets and fetch via the browser Cache API.
-- Quarto: Bypass the ~3.5 MB ipywidgets loader in favor of a small inline bootstrap.
-- Quarto: Placeholder loading shimmer so that plots occupy their full size even before loading.
-- Quarto: Optional `js+png` output mode embeds static PNG fallback for each plot so plots are visible immediately.
+# Changelog
 
 ## [0.4.1](https://github.com/meridianlabs-ai/inspect_viz/compare/v0.4.0...v0.4.1) (2026-07-09)
 
@@ -12,6 +7,13 @@
 
 * fix typo in model_info ([11e2618](https://github.com/meridianlabs-ai/inspect_viz/commit/11e26183075e182fa6052d79552f2b86a5435713))
 * fix typo in model_info & args for prepare ([4495df5](https://github.com/meridianlabs-ai/inspect_viz/commit/4495df5527c853dc365ebca8021847d06ddea6be))
+
+## 0.4.0 (April 19, 2026)
+
+- Quarto: Write plot data to content-addressed `site_data/immutable/*.arrow` assets and fetch via the browser Cache API.
+- Quarto: Bypass the ~3.5 MB ipywidgets loader in favor of a small inline bootstrap.
+- Quarto: Placeholder loading shimmer so that plots occupy their full size even before loading.
+- Quarto: Optional `js+png` output mode embeds static PNG fallback for each plot so plots are visible immediately.
 
 ## 0.3.5 (December 5, 2025)
 


### PR DESCRIPTION
Permanent fix for the changelog mis-ordering quirk. Root cause (verified in release-please source): the changelog updater inserts new sections before the first version header **preceded by a newline** (`\n###? v?[0-9[]`) — a version header on line 1 never matches, so 0.4.1 landed *below* 0.4.0. Adding the `# Changelog` title line (like flow/harbor/sandboxes/vscode, which have always ordered correctly) makes every future insertion go to the top. Also moves the existing 0.4.1 section into its correct place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)