### PR TITLE
docs: correct release-notes visibility and publish-approval wording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,19 +55,21 @@ matters. Format it as `<type>: <description>`.
 Releases are automated with [Release Please](https://github.com/googleapis/release-please):
 **don't edit `CHANGELOG.md` or bump the version by hand.** Release Please reads the
 merged commit types, opens a release PR that updates the changelog and version, and
-merging that PR tags and publishes the release.
+merging that PR tags the release; the publish then runs once a maintainer approves
+the deployment.
 
-Choose the type deliberately — only `feat:` and `fix:` appear in the release notes
-and drive the version bump:
+Choose the type deliberately — `feat:` and `fix:` drive the version bump and
+headline the release notes:
 
-| Type | Use for |
+| Type | Effect |
 | --- | --- |
-| `feat:` | a user-facing feature |
-| `fix:` | a user-facing bug fix |
-| `docs:`, `refactor:`, `perf:`, `test:`, `build:`, `chore:`, `ci:` | everything else — excluded from the release notes |
+| `feat:` | a user-facing feature — bumps the patch version (pre-1.0 policy) |
+| `fix:` | a user-facing bug fix — bumps the patch version |
+| `perf:`, `revert:` | appear in the release notes (no bump on their own) |
+| `docs:`, `refactor:`, `chore:`, `build:`, `ci:`, `test:`, `style:` | hidden from the release notes |
 
 Anything that isn't a user-facing feature or fix should avoid `feat:`/`fix:` so it
-stays out of the release notes.
+stays out of the headline sections.
 
 ## Reporting issues
 


### PR DESCRIPTION
Updates CONTRIBUTING.md to match the live Release Please config: perf/revert commits appear in the release notes, docs/refactor/chore/etc. are hidden, and both feat and fix bump the patch version under our pre-1.0 policy. Also clarifies that merging the release PR tags the release and publishing runs only after a maintainer approves the deployment (mirrors the flow#754 review fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)