### PR TITLE
docs: add PR-title and release guidance to agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,3 +19,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Testing**: Write tests with pytest; maintain high coverage
 
 Respect existing code patterns when modifying files. Run linting before committing changes.
+
+## Pull Requests
+
+- Title PRs as Conventional Commits (`<type>: <description>`)—we squash-merge, so the PR title becomes the commit message that drives releases; `pr-title-lint` enforces it
+- `feat:`/`fix:` are for user-facing changes only: they headline the release notes and bump the version. `perf:`/`revert:` also appear in the notes (no bump); `docs:`, `refactor:`, `chore:`, `build:`, `ci:`, `test:`, `style:` are hidden
+- Body lines starting with `<type>:` are parsed as extra changelog entries—don't begin description lines with a conventional-commit prefix unless that's intended
+- Never edit `CHANGELOG.md`, version numbers, or `.release-please-manifest.json`—Release Please owns them
+- See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines


### PR DESCRIPTION
Agents read CLAUDE.md/AGENTS.md automatically but not CONTRIBUTING.md, so this inlines the release-driving PR-title rules (Conventional Commits, squash-merge, Release Please ownership) into the agent instructions. Mirrors inspect_scout#533.

🤖 Generated with [Claude Code](https://claude.com/claude-code)